### PR TITLE
CSV & Html output

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The common settings you will use are:
 * `-i`, `--include`  Glob for files to include. Can be set multiple times.
 * `-x`, `--exclude`  Glob for files to exclude. Can be set multiple times.
 * `-a`, `--absolute` Report absolute path names. The default is to report only filenames.
+* `-o`, `--output`   Pic from either `text`, `csv`, or `html` format.
 
 Setting `--exclude` will override the defaults. So don't forget to ignore `node_modules/**/*.js` in addition to project specific folders.
 
@@ -130,10 +131,21 @@ You can also configure cli arguments directly inside your package.json file. Exa
     "exclude": ["+(node_modules|build|flow-typed)/**/*.js"],
     "flow_path": "flow",
     "include": ["**/*.js"],
+    "output": "text",
     "root": "."
   }
 }
 ```
+
+### Output format
+
+You can use the `--output` flag, or `-o` to set the output format of the report. All reports are printed to sdtio using console.log. The `--output` flag has no affect when `--validate` is set.
+
+The default format is `text` which prints a two column list of status values (one of `flow`, `flow weak` or `no flow`) and the filename separated by the Tab character.
+
+The `csv` option prints two columns of data where the data is wrapped in quotes and separated by `,`.
+
+The `html-table` option prints an opening and closing `<table>` tag with two columns of data. Each row contains a `data-status` attribute which can be useful for styling. There is a summary of the rows inside the `<tfoot>` element.
 
 ### Validate mode
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The common settings you will use are:
 * `-i`, `--include`  Glob for files to include. Can be set multiple times.
 * `-x`, `--exclude`  Glob for files to exclude. Can be set multiple times.
 * `-a`, `--absolute` Report absolute path names. The default is to report only filenames.
-* `-o`, `--output`   Pic from either `text`, `csv`, or `html` format.
+* `-o`, `--output`   Choose from either `text`, `csv`, or `html` format.
 
 Setting `--exclude` will override the defaults. So don't forget to ignore `node_modules/**/*.js` in addition to project specific folders.
 
@@ -139,13 +139,40 @@ You can also configure cli arguments directly inside your package.json file. Exa
 
 ### Output format
 
-You can use the `--output` flag, or `-o` to set the output format of the report. All reports are printed to sdtio using console.log. The `--output` flag has no affect when `--validate` is set.
+You can use the `--output` flag, or `-o` to set the output format of the report. All reports are printed to stdio using console.log. The `--output` flag has no affect when `--validate` is set.
 
-The default format is `text` which prints a two column list of status values (one of `flow`, `flow weak` or `no flow`) and the filename separated by the Tab character.
+The default format is `text` which prints a two column list of status value (one of `flow`, `flow weak` or `no flow`) and filename separated by the Tab character.
 
-The `csv` option prints two columns of data where the data is wrapped in quotes and separated by `,`.
+The `csv` option prints a two column list of status value and filename with each field wrapped in quotes and separated by `,`.
 
-The `html-table` option prints an opening and closing `<table>` tag with two columns of data. Each row contains a `data-status` attribute which can be useful for styling. There is a summary of the rows inside the `<tfoot>` element.
+The `html-table` option prints an opening and closing `<table>` tag with two columns of data. Each row contains a `data-status` attribute which can be useful for styling. There is a summary of the rows inside the `<tfoot>` element. This does not print a full, valid, html page but it is possible to render it directly.
+
+### VERBOSE
+
+If the `VERBOSE` env variable is set to a truthy value then the resolved configuration params will be printed:
+
+```
+$ VERBOSE=1 ./bin/flow-annotation-check.js
+Invoking: { command: 'report',
+  flags:
+   { absolute: false,
+     allow_weak: false,
+     exclude:
+      [ 'src/__tests__/fixtures/comment-blocks-10.js',
+        'src/__tests__/fixtures/comment-statement-10.js',
+        'src/__tests__/fixtures/no-comments.js' ],
+     flow_path: 'flow',
+     include: [ 'src/**/*.js' ],
+     output: 'text',
+     root: '/Users/ryan/Code/flow-annotation-check' } }
+flow  src/__tests__/cli-test.js
+flow  src/__tests__/core-test.js
+flow  src/__tests__/fixtures/comment-blocks-09.flow.js
+flow  src/__tests__/fixtures/comment-single-block-09.flow.js
+flow  src/__tests__/fixtures/comment-single-block-10.flow.js
+flow  src/__tests__/fixtures/comment-statement-09.flow.js
+... snip ...
+```
 
 ### Validate mode
 

--- a/bin/html-annotations.sh
+++ b/bin/html-annotations.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-"$(dirname $0)/flow-annotation-check.js" \
-  | awk 'BEGIN{print "<table>"} {print "<tr>";for(i=1;i<=NF;i++)print "<td>" $i"</td>";print "</tr>"} END{print "</table>"}' \
-  | tee $1

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "clean": "rm -Rf npm-debug.log lib coverage flow-coverage",
     "flow:check": "flow check && flow check ./src/__tests__/fixtures",
     "flow:annotations": "npm run transpile && bin/flow-annotation-check.js",
-    "flow:html-annotations": "./bin/html-annotations.sh",
     "flow:coverage": "flow-coverage-report report",
     "flow": "npm run flow:check && npm run flow:annotations && npm run flow:coverage",
     "jest": "jest",

--- a/src/__tests__/__snapshots__/cli-test.js.snap
+++ b/src/__tests__/__snapshots__/cli-test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cli getParser should print the help message 1`] = `
-"usage: index.js [-h] [-v] [-f FLOW_PATH] [-a] [--allow-weak] [-i INCLUDE]
-                [-x EXCLUDE] [--validate]
+"usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv}] [-a]
+                [--allow-weak] [-i INCLUDE] [-x EXCLUDE] [--validate]
                 [root]
 
 Positional arguments:
@@ -14,6 +14,9 @@ Optional arguments:
   -v, --version         Show program's version number and exit.
   -f FLOW_PATH, --flow-path FLOW_PATH
                         The path to the flow command. (default: \`\\"flow\\"\`)
+  -o {text,html-table,csv}, --output {text,html-table,csv}
+                        Output format for status/filename pairs. (default: 
+                        \`\\"text\\"\`)
   -a, --absolute        Report absolute path names. (default: \`false\`)
   --allow-weak          Consider \`@flow weak\` as a accepable annotation. See 
                         https://flowtype.org/docs/existing.html#weak-mode for 

--- a/src/__tests__/__snapshots__/printStatusReport-test.js.snap
+++ b/src/__tests__/__snapshots__/printStatusReport-test.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`printStatusReport should print a simple csv report 1`] = `
+Array [
+  "\\"flow\\", \\"./a.js\\"",
+  "\\"flow weak\\", \\"./b.js\\"",
+  "\\"no flow\\", \\"./c.js\\"",
+]
+`;
+
+exports[`printStatusReport should print a simple html-table report 1`] = `
+Array [
+  "<table>",
+  "<tbody>",
+  "<tr data-status=\\"flow\\">
+        <td>flow</td>
+        <td>./a.js</td>
+      </tr>",
+  "<tr data-status=\\"flow weak\\">
+        <td>flow weak</td>
+        <td>./b.js</td>
+      </tr>",
+  "<tr data-status=\\"no flow\\">
+        <td>no flow</td>
+        <td>./c.js</td>
+      </tr>",
+  "</tbody>",
+  "<tfoot>",
+  "<tr><td>@flow</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>@flow weak</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>no flow</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>Total Files</td><td>3</td></tr>",
+  "</tfoot>",
+  "</table>",
+]
+`;
+
+exports[`printStatusReport should print a simple text report 1`] = `
+Array [
+  "flow	./a.js",
+  "flow weak	./b.js",
+  "no flow	./c.js",
+]
+`;
+
+exports[`printStatusReport should print an empty html-table report 1`] = `
+Array [
+  "<table>",
+  "<tbody>",
+  "</tbody>",
+  "<tfoot>",
+  "<tr><td>@flow</td><td>0</td></tr>",
+  "<tr><td>@flow weak</td><td>0</td></tr>",
+  "<tr><td>no flow</td><td>0</td></tr>",
+  "<tr><td>Total Files</td><td>0</td></tr>",
+  "</tfoot>",
+  "</table>",
+]
+`;
+
+exports[`printStatusReport should print an html-table report with even percentages 1`] = `
+Array [
+  "<table>",
+  "<tbody>",
+  "<tr data-status=\\"flow\\">
+        <td>flow</td>
+        <td>./a.js</td>
+      </tr>",
+  "<tr data-status=\\"flow weak\\">
+        <td>flow weak</td>
+        <td>./b.js</td>
+      </tr>",
+  "</tbody>",
+  "<tfoot>",
+  "<tr><td>@flow</td><td>1 (50%)</td></tr>",
+  "<tr><td>@flow weak</td><td>1 (50%)</td></tr>",
+  "<tr><td>no flow</td><td>0 (0%)</td></tr>",
+  "<tr><td>Total Files</td><td>2</td></tr>",
+  "</tfoot>",
+  "</table>",
+]
+`;

--- a/src/__tests__/cli-test.js
+++ b/src/__tests__/cli-test.js
@@ -13,6 +13,7 @@ const DEFAULT_FLAGS = {
   exclude: ['+(node_modules|build|flow-typed)/**/*.js'],
   flow_path: 'flow',
   include: ['**/*.js'],
+  output: 'text',
   root: '.',
 };
 
@@ -35,6 +36,7 @@ describe('cli', () => {
         exclude: ['+(node_modules|build|flow-typed)/**/*.js'],
         flow_path: 'flow',
         include: ['**/*.js'],
+        output: 'text',
         root: path.resolve(path.join(__dirname, '../..')),
       });
     });

--- a/src/__tests__/flow-test.js
+++ b/src/__tests__/flow-test.js
@@ -82,6 +82,7 @@ describe('genForceErrors', () => {
     exclude: [],
     flow_path: 'flow',
     include: [],
+    output: 'text',
     root: '.',
   };
 

--- a/src/__tests__/printStatusReport-test.js
+++ b/src/__tests__/printStatusReport-test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+import {
+  asText,
+  asHTMLTable,
+  asCSV,
+} from '../printStatusReport';
+
+const BASIC_REPORT: StatusReport = [
+  {status: 'flow', file: './a.js'},
+  {status: 'flow weak', file: './b.js'},
+  {status: 'no flow', file: './c.js'},
+];
+
+describe('printStatusReport', () => {
+  it('should print a simple text report', () => {
+    expect(asText(BASIC_REPORT)).toMatchSnapshot();
+  });
+  it('should print a simple csv report', () => {
+    expect(asCSV(BASIC_REPORT)).toMatchSnapshot();
+  });
+  it('should print a simple html-table report', () => {
+    expect(asHTMLTable(BASIC_REPORT)).toMatchSnapshot();
+  });
+  it('should print an empty html-table report', () => {
+    const report = [];
+    expect(asHTMLTable(report)).toMatchSnapshot();
+  });
+  it('should print an html-table report with even percentages', () => {
+    const report = [
+      {status: 'flow', file: './a.js'},
+      {status: 'flow weak', file: './b.js'},
+    ];
+    expect(asHTMLTable(report)).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/printStatusReport-test.js
+++ b/src/__tests__/printStatusReport-test.js
@@ -10,7 +10,7 @@ import {
   asCSV,
 } from '../printStatusReport';
 
-const BASIC_REPORT: StatusReport = [
+const BASIC_REPORT = [
   {status: 'flow', file: './a.js'},
   {status: 'flow weak', file: './b.js'},
   {status: 'no flow', file: './c.js'},

--- a/src/printStatusReport.js
+++ b/src/printStatusReport.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+import type {FlowStatus, StatusReport} from './types';
+
+export function asText(report: StatusReport): Array<string> {
+  return report.map((entry) => `${entry.status}\t${entry.file}`);
+}
+
+export function asHTMLTable(report: StatusReport): Array<string> {
+  function htmlPair(first: string, second: string) {
+    return `<tr><td>${first}</td><td>${second}</td></tr>`;
+  }
+  function htmlCount(status: FlowStatus): string {
+    const count = report.filter((entry) => entry.status === status).length
+    return report.length === 0
+      ? '0'
+      : `${count} (${Math.round(count/report.length * 10000) / 100}%)`;
+  }
+
+  return [
+    '<table>',
+    '<tbody>',
+    ...report.map((entry) =>
+      `<tr data-status="${entry.status}">
+        <td>${entry.status}</td>
+        <td>${entry.file}</td>
+      </tr>`
+    ),
+    '</tbody>',
+    '<tfoot>',
+    htmlPair('@flow', htmlCount('flow')),
+    htmlPair('@flow weak', htmlCount('flow weak')),
+    htmlPair('no flow', htmlCount('no flow')),
+    htmlPair('Total Files', String(report.length)),
+    '</tfoot>',
+    '</table>'
+  ];
+}
+
+export function asCSV(report: StatusReport): Array<string> {
+  return report.map((entry) => [
+      JSON.stringify(entry.status),
+      JSON.stringify(entry.file),
+    ].join(', ')
+  );
+}

--- a/src/types.js
+++ b/src/types.js
@@ -2,12 +2,15 @@
  * @flow
  */
 
+export type OutputFormat = 'text' | 'html-table' | 'csv';
+
 export type Args = {
   absolute?: boolean,
   allow_weak?: boolean,
   exclude?: Array<string>,
   flow_path?: string,
   include?: Array<string>,
+  output?: OutputFormat,
   root?: string,
 };
 
@@ -17,6 +20,7 @@ export type Flags = {
   exclude: string | Array<string>,
   flow_path: string,
   include: string | Array<string>,
+  output: OutputFormat,
   root: string,
 };
 


### PR DESCRIPTION
Add new csv and html output options.

The csv option is a simple wrapper over the original text output, but adds json escaping for values
The HTMl-table option just prints a simple <table> element, not a while page. It's got `data-status` attributes on the <tr> elements for custom styling, and tbody/tfoot elements as well. the tfoot has some summary data in it.