### PR TITLE
Add jUnit output and ability to create multiple report types in one run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The common settings you will use are:
 * `-i`, `--include`  Glob for files to include. Can be set multiple times.
 * `-x`, `--exclude`  Glob for files to exclude. Can be set multiple times.
 * `-a`, `--absolute` Report absolute path names. The default is to report only filenames.
-* `-o`, `--output`   Choose from either `text`, `csv`, or `html` format.
+* `-o`, `--output`   Choose from either `text`, `csv`, 'junit', or `html` format.
 
 Setting `--exclude` will override the defaults. So don't forget to ignore `node_modules/**/*.js` in addition to project specific folders.
 
@@ -145,14 +145,21 @@ The default format is `text` which prints a two column list of status value (one
 
 The `csv` option prints a two column list of status value and filename with each field wrapped in quotes and separated by `,`.
 
-The `html-table` option prints an opening and closing `<table>` tag with two columns of data. Each row contains a `data-status` attribute which can be useful for styling. There is a summary of the rows inside the `<tfoot>` element. This does not print a full, valid, html page but it is possible to render it directly.
+The `junit` option prints an xml report suitable to be consumed by CI tools like Jenkins.
+
+The `html-table` option prints an opening and closing `<table>` tag with two columns of data. Each row contains a `data-status` attribute which can be useful for styling. There is a summary of the rows inside the `<tfoot>` element. This does not print a full, valid, html page but it is possible to render it directly. This option, with some custom CSS, could be used as part of a dashboard where only the names of the non-flow files are listed.
+
+In addition to the `--output` flag there are other flags that will return the report in different formats and save it directly to a file for you. You can set `--html-file`, `--csv-file` or `--junit-file` and each one will create a file containing the respective report. This is useful for getting the report in multiple formats at the same time.
+
+For example, it is desirable for CI logs to not have any extra markup and use the default `text` format with the `-o` flag. But at the same time possible to use the `--junit-file` flag to feed some data into jenkins for tracking over time.
+
 
 ### VERBOSE
 
-If the `VERBOSE` env variable is set to a truthy value then the resolved configuration params will be printed:
+If the `VERBOSE` env variable is set to a truthy value then the resolved configuration params will be printed. The config is a union of defaults, values in package.json, and CLI flags. Example:
 
 ```
-$ VERBOSE=1 ./bin/flow-annotation-check.js
+$ VERBOSE=1 flow-annotation-check
 Invoking: { command: 'report',
   flags:
    { absolute: false,

--- a/src/__tests__/__snapshots__/cli-test.js.snap
+++ b/src/__tests__/__snapshots__/cli-test.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cli getParser should print the help message 1`] = `
-"usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,xunit}] [-a]
-                [--allow-weak] [-i INCLUDE] [-x EXCLUDE] [--validate]
+"usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,xunit}]
+                [--html-file HTML_FILE] [--csv-file CSV_FILE]
+                [--junit-file JUNIT_FILE] [-a] [--allow-weak] [-i INCLUDE]
+                [-x EXCLUDE] [--validate]
                 [root]
 
 Positional arguments:
@@ -17,6 +19,14 @@ Optional arguments:
   -o {text,html-table,csv,xunit}, --output {text,html-table,csv,xunit}
                         Output format for status/filename pairs. (default: 
                         \`\\"text\\"\`)
+  --html-file HTML_FILE
+                        Save the html table output directly into HTML_FILE. 
+                        (default: \`null\`)
+  --csv-file CSV_FILE   Save CSV output directly into CSV_FILE. (default: 
+                        \`null\`)
+  --junit-file JUNIT_FILE
+                        Save jUnit output directly into JUNIT_FILE. (default: 
+                        \`null\`)
   -a, --absolute        Report absolute path names. (default: \`false\`)
   --allow-weak          Consider \`@flow weak\` as a accepable annotation. See 
                         https://flowtype.org/docs/existing.html#weak-mode for 

--- a/src/__tests__/__snapshots__/cli-test.js.snap
+++ b/src/__tests__/__snapshots__/cli-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cli getParser should print the help message 1`] = `
-"usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,xunit}]
+"usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,junit}]
                 [--html-file HTML_FILE] [--csv-file CSV_FILE]
                 [--junit-file JUNIT_FILE] [-a] [--allow-weak] [-i INCLUDE]
                 [-x EXCLUDE] [--validate]
@@ -16,7 +16,7 @@ Optional arguments:
   -v, --version         Show program's version number and exit.
   -f FLOW_PATH, --flow-path FLOW_PATH
                         The path to the flow command. (default: \`\\"flow\\"\`)
-  -o {text,html-table,csv,xunit}, --output {text,html-table,csv,xunit}
+  -o {text,html-table,csv,junit}, --output {text,html-table,csv,junit}
                         Output format for status/filename pairs. (default: 
                         \`\\"text\\"\`)
   --html-file HTML_FILE

--- a/src/__tests__/__snapshots__/cli-test.js.snap
+++ b/src/__tests__/__snapshots__/cli-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cli getParser should print the help message 1`] = `
-"usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv}] [-a]
+"usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,xunit}] [-a]
                 [--allow-weak] [-i INCLUDE] [-x EXCLUDE] [--validate]
                 [root]
 
@@ -14,7 +14,7 @@ Optional arguments:
   -v, --version         Show program's version number and exit.
   -f FLOW_PATH, --flow-path FLOW_PATH
                         The path to the flow command. (default: \`\\"flow\\"\`)
-  -o {text,html-table,csv}, --output {text,html-table,csv}
+  -o {text,html-table,csv,xunit}, --output {text,html-table,csv,xunit}
                         Output format for status/filename pairs. (default: 
                         \`\\"text\\"\`)
   -a, --absolute        Report absolute path names. (default: \`false\`)

--- a/src/__tests__/__snapshots__/parser-test.js.snap
+++ b/src/__tests__/__snapshots__/parser-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cli getParser should print the help message 1`] = `
+exports[`getParser should print the help message 1`] = `
 "usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,junit}]
                 [--html-file HTML_FILE] [--csv-file CSV_FILE]
                 [--junit-file JUNIT_FILE] [-a] [--allow-weak] [-i INCLUDE]

--- a/src/__tests__/__snapshots__/printStatusReport-test.js.snap
+++ b/src/__tests__/__snapshots__/printStatusReport-test.js.snap
@@ -80,3 +80,13 @@ Array [
   "</table>",
 ]
 `;
+
+exports[`printStatusReport should print an xunit compatible report 1`] = `
+Array [
+  "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"3\\" failures=\\"2\\" errors=\\"0\\">",
+  "<testcase classname=\\"./a.js\\" name=\\"HasFlowStatus\\" time=\\"0\\" />",
+  "<testcase classname=\\"./b.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">File has status flow weak</failure></testcase>",
+  "<testcase classname=\\"./c.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasNoneStatus\\">File has status no flow</failure></testcase>",
+  "</testsuite>",
+]
+`;

--- a/src/__tests__/__snapshots__/printStatusReport-test.js.snap
+++ b/src/__tests__/__snapshots__/printStatusReport-test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`printStatusReport should print a jUnit compatible report 1`] = `
+Array [
+  "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"3\\" failures=\\"2\\" errors=\\"0\\">",
+  "<testcase classname=\\"./a.js\\" name=\\"HasFlowStatus\\" time=\\"0\\" />",
+  "<testcase classname=\\"./b.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">File has status flow weak</failure></testcase>",
+  "<testcase classname=\\"./c.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasNoneStatus\\">File has status no flow</failure></testcase>",
+  "</testsuite>",
+]
+`;
+
 exports[`printStatusReport should print a simple csv report 1`] = `
 Array [
   "\\"flow\\", \\"./a.js\\"",
@@ -78,15 +88,5 @@ Array [
   "<tr><td>Total Files</td><td>2</td></tr>",
   "</tfoot>",
   "</table>",
-]
-`;
-
-exports[`printStatusReport should print an xunit compatible report 1`] = `
-Array [
-  "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"3\\" failures=\\"2\\" errors=\\"0\\">",
-  "<testcase classname=\\"./a.js\\" name=\\"HasFlowStatus\\" time=\\"0\\" />",
-  "<testcase classname=\\"./b.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">File has status flow weak</failure></testcase>",
-  "<testcase classname=\\"./c.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasNoneStatus\\">File has status no flow</failure></testcase>",
-  "</testsuite>",
 ]
 `;

--- a/src/__tests__/__snapshots__/printStatusReport-test.js.snap
+++ b/src/__tests__/__snapshots__/printStatusReport-test.js.snap
@@ -4,8 +4,8 @@ exports[`printStatusReport should print a jUnit compatible report 1`] = `
 Array [
   "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"3\\" failures=\\"2\\" errors=\\"0\\">",
   "<testcase classname=\\"./a.js\\" name=\\"HasFlowStatus\\" time=\\"0\\" />",
-  "<testcase classname=\\"./b.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">File has status flow weak</failure></testcase>",
-  "<testcase classname=\\"./c.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasNoneStatus\\">File has status no flow</failure></testcase>",
+  "<testcase classname=\\"./b.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">Status is \\"flow weak\\"</failure></testcase>",
+  "<testcase classname=\\"./c.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasNoneStatus\\">Status is \\"no flow\\"</failure></testcase>",
   "</testsuite>",
 ]
 `;

--- a/src/__tests__/cli-test.js
+++ b/src/__tests__/cli-test.js
@@ -9,11 +9,6 @@ import {getParser, main, resolveArgs} from '../cli';
 import {DEFAULT_FLAGS} from '../types';
 
 describe('cli', () => {
-  describe('getParser', () => {
-    it('should print the help message', () => {
-      expect(getParser().formatHelp()).toMatchSnapshot();
-    });
-  });
   describe('resolveArgs', () => {
     const MOCK_ARGS = {
       root: '.',

--- a/src/__tests__/cli-test.js
+++ b/src/__tests__/cli-test.js
@@ -6,19 +6,7 @@
 
 import path from 'path';
 import {getParser, main, resolveArgs} from '../cli';
-
-const DEFAULT_FLAGS = {
-  absolute: false,
-  allow_weak: false,
-  exclude: ['+(node_modules|build|flow-typed)/**/*.js'],
-  flow_path: 'flow',
-  include: ['**/*.js'],
-  output: 'text',
-  html_file: null,
-  csv_file: null,
-  junit_file: null,
-  root: '.',
-};
+import {DEFAULT_FLAGS} from '../types';
 
 describe('cli', () => {
   describe('getParser', () => {

--- a/src/__tests__/cli-test.js
+++ b/src/__tests__/cli-test.js
@@ -14,6 +14,9 @@ const DEFAULT_FLAGS = {
   flow_path: 'flow',
   include: ['**/*.js'],
   output: 'text',
+  html_file: null,
+  csv_file: null,
+  junit_file: null,
   root: '.',
 };
 
@@ -37,6 +40,9 @@ describe('cli', () => {
         flow_path: 'flow',
         include: ['**/*.js'],
         output: 'text',
+        html_file: null,
+        csv_file: null,
+        junit_file: null,
         root: path.resolve(path.join(__dirname, '../..')),
       });
     });

--- a/src/__tests__/flow-test.js
+++ b/src/__tests__/flow-test.js
@@ -83,6 +83,9 @@ describe('genForceErrors', () => {
     flow_path: 'flow',
     include: [],
     output: 'text',
+    html_file: null,
+    csv_file: null,
+    junit_file: null,
     root: '.',
   };
 

--- a/src/__tests__/parser-test.js
+++ b/src/__tests__/parser-test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+import path from 'path';
+import getParser from '../parser';
+import {DEFAULT_FLAGS} from '../types';
+
+describe('getParser', () => {
+  it('should print the help message', () => {
+    expect(getParser().formatHelp()).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/printStatusReport-test.js
+++ b/src/__tests__/printStatusReport-test.js
@@ -8,7 +8,7 @@ import {
   asText,
   asHTMLTable,
   asCSV,
-  asXUnit,
+  asJUnit,
 } from '../printStatusReport';
 
 import os from 'os';
@@ -47,7 +47,7 @@ describe('printStatusReport', () => {
     ];
     expect(asHTMLTable(report)).toMatchSnapshot();
   });
-  it('should print an xunit compatible report', () => {
-    expect(asXUnit(BASIC_REPORT)).toMatchSnapshot();
+  it('should print a jUnit compatible report', () => {
+    expect(asJUnit(BASIC_REPORT)).toMatchSnapshot();
   });
 });

--- a/src/__tests__/printStatusReport-test.js
+++ b/src/__tests__/printStatusReport-test.js
@@ -8,7 +8,10 @@ import {
   asText,
   asHTMLTable,
   asCSV,
+  asXUnit,
 } from '../printStatusReport';
+
+import os from 'os';
 
 const BASIC_REPORT = [
   {status: 'flow', file: './a.js'},
@@ -17,6 +20,13 @@ const BASIC_REPORT = [
 ];
 
 describe('printStatusReport', () => {
+  beforeEach(() => {
+    global.Date = jest.fn(() => ({
+      toISOString: () => '-mock date-',
+    }));
+    os.hostname = jest.fn(() => 'test-host');
+  });
+
   it('should print a simple text report', () => {
     expect(asText(BASIC_REPORT)).toMatchSnapshot();
   });
@@ -36,5 +46,8 @@ describe('printStatusReport', () => {
       {status: 'flow weak', file: './b.js'},
     ];
     expect(asHTMLTable(report)).toMatchSnapshot();
+  });
+  it('should print an xunit compatible report', () => {
+    expect(asXUnit(BASIC_REPORT)).toMatchSnapshot();
   });
 });

--- a/src/__tests__/promisified-test.js
+++ b/src/__tests__/promisified-test.js
@@ -7,7 +7,7 @@
 jest.mock('child_process');
 jest.mock('fs');
 
-import {exec, execFile, stat, append, truncate} from '../promisified';
+import {exec, execFile, stat, write, append, truncate} from '../promisified';
 const childProcess = require('child_process');
 const fs = require('fs');
 
@@ -136,6 +136,44 @@ describe('promisified', () => {
 
       const callbackArg = fs.stat.mock.calls[0][1];
       callbackArg('failed', 'bytes: ?');
+
+      return promise;
+    });
+  });
+
+  describe('write', () => {
+    beforeEach(() => {
+      fs.writeFile.mockReset();
+    });
+
+    it('passes args through to fs.writeFile', () => {
+      write('foo.js', 'foo bar');
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        'foo.js',
+        'foo bar',
+        expect.any(Function),
+      );
+    });
+
+    it('resolves when no cli error is thrown', () => {
+      const promise = write('foo.js', 'foo bar').then((result) => {
+        expect(result).toBeUndefined();
+      });
+
+      const callbackArg = fs.writeFile.mock.calls[0][2];
+      callbackArg(null, 'foo bar');
+
+      return promise;
+    });
+
+    it('throws when a cli error happens', () => {
+      const promise = write('foo.js', 'foo bar').catch((result) => {
+        expect(result).toEqual('failed');
+      });
+
+      const callbackArg = fs.writeFile.mock.calls[0][2];
+      callbackArg('failed', 'foo bar');
 
       return promise;
     });

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,7 @@ import {
   asText as printStatusReportAsText,
   asHTMLTable as printStatusReportAsHTMLTable,
   asCSV as printStatusReportAsCSV,
+  asXUnit as printStatusReportAsXUnit,
 } from './printStatusReport';
 
 const DEFAULT_FLAGS: Flags = {
@@ -49,7 +50,7 @@ function getParser(): ArgumentParser {
     {
       action: 'store',
       help: `Output format for status/filename pairs. ${printDefault(DEFAULT_FLAGS.output)} `,
-      choices: ['text', 'html-table', 'csv'],
+      choices: ['text', 'html-table', 'csv', 'xunit'],
     },
   );
   parser.addArgument(
@@ -154,6 +155,8 @@ function getReport(report: StatusReport, flags: Flags): Array<string> {
       return printStatusReportAsHTMLTable(report);
     case 'csv':
       return printStatusReportAsCSV(report);
+    case 'xunit':
+      return printStatusReportAsXUnit(report);
     default:
       throw new Error(`Invalid flag \`output\`. Found: ${JSON.stringify(flags.output)}`);
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,13 +5,12 @@
  */
 
 import type {Args, Flags, OutputFormat, StatusReport, ValidationReport} from './types';
-import {DEFAULT_FLAGS, OutputFormats} from './types';
+import {DEFAULT_FLAGS} from './types';
 
 import genReport, {genValidate} from './flow-annotation-check';
+import getParser from './parser';
 import loadPkg from 'load-pkg';
-import packageJSON from '../package.json';
 import path from 'path';
-import {ArgumentParser} from 'argparse';
 import {write} from './promisified';
 import {
   asText as printStatusReportAsText,
@@ -20,98 +19,6 @@ import {
   asJUnit as printStatusReportAsJUnit,
 } from './printStatusReport';
 
-function printDefault(value) {
-  return `(default: \`${JSON.stringify(value)}\`)`;
-}
-
-function getParser(): ArgumentParser {
-  const parser = new ArgumentParser({
-    addHelp: true,
-    version: packageJSON.version,
-  });
-
-  parser.addArgument(
-    ['-f', '--flow-path'],
-    {
-      action: 'store',
-      help: `The path to the flow command. ${printDefault(DEFAULT_FLAGS.flow_path)}`,
-    },
-  );
-  parser.addArgument(
-    ['-o', '--output'],
-    {
-      action: 'store',
-      help: `Output format for status/filename pairs. ${printDefault(DEFAULT_FLAGS.output)} `,
-      choices: OutputFormats,
-    },
-  );
-  parser.addArgument(
-    ['--html-file'],
-    {
-      action: 'store',
-      help: `Save the html table output directly into HTML_FILE. ${printDefault(DEFAULT_FLAGS.html_file)} `,
-    },
-  );
-  parser.addArgument(
-    ['--csv-file'],
-    {
-      action: 'store',
-      help: `Save CSV output directly into CSV_FILE. ${printDefault(DEFAULT_FLAGS.csv_file)} `,
-    },
-  );
-  parser.addArgument(
-    ['--junit-file'],
-    {
-      action: 'store',
-      help: `Save jUnit output directly into JUNIT_FILE. ${printDefault(DEFAULT_FLAGS.junit_file)} `,
-    },
-  );
-  parser.addArgument(
-    ['-a', '--absolute'],
-    {
-      action: 'storeTrue',
-      help: `Report absolute path names. ${printDefault(DEFAULT_FLAGS.absolute)}`,
-    },
-  );
-  parser.addArgument(
-    ['--allow-weak'],
-    {
-      action: 'storeTrue',
-      help: `Consider \`@flow weak\` as a accepable annotation. See https://flowtype.org/docs/existing.html#weak-mode for reasons why this should only be used temporarily. ${printDefault(DEFAULT_FLAGS.allow_weak)}`,
-    },
-  );
-  parser.addArgument(
-    ['-i', '--include'],
-    {
-      action: 'append',
-      help: `Glob for files to include. Can be set multiple times. ${printDefault(DEFAULT_FLAGS.include)}`,
-    },
-  );
-  parser.addArgument(
-    ['-x', '--exclude'],
-    {
-      action: 'append',
-      help: `Glob for files to exclude. Can be set multiple times. ${printDefault(DEFAULT_FLAGS.exclude)}`,
-    },
-  );
-  parser.addArgument(
-    ['--validate'],
-    {
-      action: 'storeTrue',
-      help: 'Run in validation mode. This injects errors into globbed files and checks the flow-annotation status',
-    },
-  );
-  parser.addArgument(
-    ['root'],
-    {
-      defaultValue: '.',
-      help: `The root directory to glob files from. ${printDefault(DEFAULT_FLAGS.root)}`,
-      nargs: '?',
-    },
-  );
-
-  return parser;
-}
 
 function getPackageJsonArgs(root: ?string, defaults: Flags): Flags {
   var pkg = loadPkg.sync(path.resolve(root || defaults.root));

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,7 @@
  */
 
 import type {Args, Flags, OutputFormat, StatusReport, ValidationReport} from './types';
-import {OutputFormats} from './types';
+import {DEFAULT_FLAGS, OutputFormats} from './types';
 
 import genReport, {genValidate} from './flow-annotation-check';
 import loadPkg from 'load-pkg';
@@ -19,19 +19,6 @@ import {
   asCSV as printStatusReportAsCSV,
   asJUnit as printStatusReportAsJUnit,
 } from './printStatusReport';
-
-const DEFAULT_FLAGS: Flags = {
-  absolute: false,
-  allow_weak: false,
-  exclude: ['+(node_modules|build|flow-typed)/**/*.js'],
-  flow_path: 'flow',
-  include: ['**/*.js'],
-  output: 'text',
-  html_file: null,
-  csv_file: null,
-  junit_file: null,
-  root: '.',
-};
 
 function printDefault(value) {
   return `(default: \`${JSON.stringify(value)}\`)`;

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+import packageJSON from '../package.json';
+import {ArgumentParser} from 'argparse';
+import {DEFAULT_FLAGS, OutputFormats} from './types';
+
+function printDefault(value) {
+  return `(default: \`${JSON.stringify(value)}\`)`;
+}
+
+export default function getParser(): ArgumentParser {
+  const parser = new ArgumentParser({
+    addHelp: true,
+    version: packageJSON.version,
+  });
+
+  parser.addArgument(
+    ['-f', '--flow-path'],
+    {
+      action: 'store',
+      help: `The path to the flow command. ${printDefault(DEFAULT_FLAGS.flow_path)}`,
+    },
+  );
+  parser.addArgument(
+    ['-o', '--output'],
+    {
+      action: 'store',
+      help: `Output format for status/filename pairs. ${printDefault(DEFAULT_FLAGS.output)} `,
+      choices: OutputFormats,
+    },
+  );
+  parser.addArgument(
+    ['--html-file'],
+    {
+      action: 'store',
+      help: `Save the html table output directly into HTML_FILE. ${printDefault(DEFAULT_FLAGS.html_file)} `,
+    },
+  );
+  parser.addArgument(
+    ['--csv-file'],
+    {
+      action: 'store',
+      help: `Save CSV output directly into CSV_FILE. ${printDefault(DEFAULT_FLAGS.csv_file)} `,
+    },
+  );
+  parser.addArgument(
+    ['--junit-file'],
+    {
+      action: 'store',
+      help: `Save jUnit output directly into JUNIT_FILE. ${printDefault(DEFAULT_FLAGS.junit_file)} `,
+    },
+  );
+  parser.addArgument(
+    ['-a', '--absolute'],
+    {
+      action: 'storeTrue',
+      help: `Report absolute path names. ${printDefault(DEFAULT_FLAGS.absolute)}`,
+    },
+  );
+  parser.addArgument(
+    ['--allow-weak'],
+    {
+      action: 'storeTrue',
+      help: `Consider \`@flow weak\` as a accepable annotation. See https://flowtype.org/docs/existing.html#weak-mode for reasons why this should only be used temporarily. ${printDefault(DEFAULT_FLAGS.allow_weak)}`,
+    },
+  );
+  parser.addArgument(
+    ['-i', '--include'],
+    {
+      action: 'append',
+      help: `Glob for files to include. Can be set multiple times. ${printDefault(DEFAULT_FLAGS.include)}`,
+    },
+  );
+  parser.addArgument(
+    ['-x', '--exclude'],
+    {
+      action: 'append',
+      help: `Glob for files to exclude. Can be set multiple times. ${printDefault(DEFAULT_FLAGS.exclude)}`,
+    },
+  );
+  parser.addArgument(
+    ['--validate'],
+    {
+      action: 'storeTrue',
+      help: 'Run in validation mode. This injects errors into globbed files and checks the flow-annotation status',
+    },
+  );
+  parser.addArgument(
+    ['root'],
+    {
+      defaultValue: '.',
+      help: `The root directory to glob files from. ${printDefault(DEFAULT_FLAGS.root)}`,
+      nargs: '?',
+    },
+  );
+
+  return parser;
+}

--- a/src/printStatusReport.js
+++ b/src/printStatusReport.js
@@ -72,7 +72,7 @@ export function asJUnit(report: StatusReport): Array<string> {
       : [
           `<testcase classname="${escapeXML(entry.file)}" name="HasFlowStatus" time="0">`,
           `<failure type="${entry.status === 'no flow' ? 'HasNoneStatus' : 'HasFlowWeakStatus'}">`,
-          `File has status ${entry.status}`,
+          `Status is "${entry.status}"`,
           `</failure>`,
           `</testcase>`,
         ].join(''),

--- a/src/printStatusReport.js
+++ b/src/printStatusReport.js
@@ -60,9 +60,9 @@ export function asCSV(report: StatusReport): Array<string> {
   );
 }
 
-export function asXUnit(report: StatusReport): Array<string> {
+export function asJUnit(report: StatusReport): Array<string> {
   const date = (new Date()).toISOString();
-  const host = os.hostname() || 'unknown';
+  const host = os.hostname();
   const tests = report.length;
   const failures = report.length - report.filter((entry) => entry.status === 'flow').length;
   return [

--- a/src/printStatusReport.js
+++ b/src/printStatusReport.js
@@ -6,35 +6,46 @@
 
 import type {FlowStatus, StatusReport} from './types';
 
+import os from 'os';
+
+function htmlPair(first: string, second: string) {
+  return `<tr><td>${first}</td><td>${second}</td></tr>`;
+}
+
+function countByStatus(report: StatusReport, status: FlowStatus): string {
+  const count = report.filter((entry) => entry.status === status).length
+  return report.length === 0
+    ? '0'
+    : `${count} (${Math.round(count/report.length * 10000) / 100}%)`;
+}
+
+function escapeXML(value: string): string {
+  return value.replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 export function asText(report: StatusReport): Array<string> {
   return report.map((entry) => `${entry.status}\t${entry.file}`);
 }
 
 export function asHTMLTable(report: StatusReport): Array<string> {
-  function htmlPair(first: string, second: string) {
-    return `<tr><td>${first}</td><td>${second}</td></tr>`;
-  }
-  function htmlCount(status: FlowStatus): string {
-    const count = report.filter((entry) => entry.status === status).length
-    return report.length === 0
-      ? '0'
-      : `${count} (${Math.round(count/report.length * 10000) / 100}%)`;
-  }
-
   return [
     '<table>',
     '<tbody>',
     ...report.map((entry) =>
       `<tr data-status="${entry.status}">
         <td>${entry.status}</td>
-        <td>${entry.file}</td>
+        <td>${escapeXML(entry.file)}</td>
       </tr>`
     ),
     '</tbody>',
     '<tfoot>',
-    htmlPair('@flow', htmlCount('flow')),
-    htmlPair('@flow weak', htmlCount('flow weak')),
-    htmlPair('no flow', htmlCount('no flow')),
+    htmlPair('@flow', countByStatus(report, 'flow')),
+    htmlPair('@flow weak', countByStatus(report, 'flow weak')),
+    htmlPair('no flow', countByStatus(report, 'no flow')),
     htmlPair('Total Files', String(report.length)),
     '</tfoot>',
     '</table>'
@@ -47,4 +58,25 @@ export function asCSV(report: StatusReport): Array<string> {
       JSON.stringify(entry.file),
     ].join(', ')
   );
+}
+
+export function asXUnit(report: StatusReport): Array<string> {
+  const date = (new Date()).toISOString();
+  const host = os.hostname() || 'unknown';
+  const tests = report.length;
+  const failures = report.length - report.filter((entry) => entry.status === 'flow').length;
+  return [
+    `<testsuite name="flow-annotation-check" timestamp="${date}" time="0" hostname="${host}" tests="${tests}" failures="${failures}" errors="0">`,
+    ...report.map((entry) => entry.status === 'flow'
+      ? `<testcase classname="${escapeXML(entry.file)}" name="HasFlowStatus" time="0" />`
+      : [
+          `<testcase classname="${escapeXML(entry.file)}" name="HasFlowStatus" time="0">`,
+          `<failure type="${entry.status === 'no flow' ? 'HasNoneStatus' : 'HasFlowWeakStatus'}">`,
+          `File has status ${entry.status}`,
+          `</failure>`,
+          `</testcase>`,
+        ].join(''),
+    ),
+    '</testsuite>',
+  ];
 }

--- a/src/promisified.js
+++ b/src/promisified.js
@@ -60,6 +60,18 @@ function stat(file: string): Promise<{size: number}> {
   });
 }
 
+function write(file: string, data: *): Promise<typeof undefined> {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(file, data, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 function append(file: string, data: *): Promise<typeof undefined> {
   return new Promise((resolve, reject) => {
     fs.appendFile(file, data, (error) => {
@@ -86,4 +98,5 @@ export {
   stat,
   append,
   truncate,
+  write,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,13 @@
  * @flow
  */
 
-export type OutputFormat = 'text' | 'html-table' | 'csv' | 'xunit';
+export type OutputFormat = 'text' | 'html-table' | 'csv' | 'junit';
+export const OutputFormats = {
+  text: 'text',
+  'html-table': 'html-table',
+  csv: 'csv',
+  junit: 'junit',
+};
 
 export type Args = {
   absolute?: boolean,
@@ -11,6 +17,9 @@ export type Args = {
   flow_path?: string,
   include?: Array<string>,
   output?: OutputFormat,
+  html_file?: string,
+  csv_file?: string,
+  junit_file?: string,
   root?: string,
 };
 
@@ -21,6 +30,9 @@ export type Flags = {
   flow_path: string,
   include: string | Array<string>,
   output: OutputFormat,
+  html_file: ?string,
+  csv_file: ?string,
+  junit_file: ?string,
   root: string,
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-export type OutputFormat = 'text' | 'html-table' | 'csv';
+export type OutputFormat = 'text' | 'html-table' | 'csv' | 'xunit';
 
 export type Args = {
   absolute?: boolean,

--- a/src/types.js
+++ b/src/types.js
@@ -36,6 +36,19 @@ export type Flags = {
   root: string,
 };
 
+export const DEFAULT_FLAGS: Flags = {
+  absolute: false,
+  allow_weak: false,
+  exclude: ['+(node_modules|build|flow-typed)/**/*.js'],
+  flow_path: 'flow',
+  include: ['**/*.js'],
+  output: 'text',
+  html_file: null,
+  csv_file: null,
+  junit_file: null,
+  root: '.',
+};
+
 export type FlowStatus = 'flow' | 'flow weak' | 'no flow';
 
 export type StatusEntry = {


### PR DESCRIPTION
This adds the `junit` output type to the report, which is compatible with the 'Publish JUnit test results report' jenkins plugin.

Also, this adds new flags called `--html-file`, `--csv-file` and `--junit-file` which take a filename as a parameter and will print the corresponding report into that file. This allows for exporting multiple report formats after a single run. Can be good for CI environments. 
NB all printing to the console or files happens after all files are inspected.