### PR TITLE
Add a new --summarize-only flag

### DIFF
--- a/src/__tests__/__snapshots__/parser-test.js.snap
+++ b/src/__tests__/__snapshots__/parser-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`getParser should print the help message 1`] = `
 "usage: index.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,junit}]
-                [--html-file HTML_FILE] [--csv-file CSV_FILE]
+                [--summary-only] [--html-file HTML_FILE] [--csv-file CSV_FILE]
                 [--junit-file JUNIT_FILE] [-a] [--allow-weak] [-i INCLUDE]
                 [-x EXCLUDE] [--validate]
                 [root]
@@ -19,6 +19,9 @@ Optional arguments:
   -o {text,html-table,csv,junit}, --output {text,html-table,csv,junit}
                         Output format for status/filename pairs. (default: 
                         \`\\"text\\"\`)
+  --summary-only        Output just the summary data, skipping the long list 
+                        of files. Does not apply to saved file output. 
+                        (default: \`false\`)
   --html-file HTML_FILE
                         Save the html table output directly into HTML_FILE. 
                         (default: \`null\`)

--- a/src/__tests__/__snapshots__/printStatusReport-test.js.snap
+++ b/src/__tests__/__snapshots__/printStatusReport-test.js.snap
@@ -1,6 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`printStatusReport should print a jUnit compatible report 1`] = `
+exports[`printStatusReport asCSV should print a simple csv report 1`] = `
+Array [
+  "\\"flow\\", \\"./a.js\\"",
+  "\\"flow weak\\", \\"./b.js\\"",
+  "\\"no flow\\", \\"./c.js\\"",
+]
+`;
+
+exports[`printStatusReport asCSV should print a summarized csv report 1`] = `
+Array [
+  "\\"@flow\\", \\"1 (33.33%)\\"",
+  "\\"@flow weak\\", \\"1 (33.33%)\\"",
+  "\\"no flow\\", \\"1 (33.33%)\\"",
+  "\\"Total Files\\", \\"3\\"",
+]
+`;
+
+exports[`printStatusReport asHTMLTable should print a simple html-table report 1`] = `
+Array [
+  "<table>",
+  "<tfoot>",
+  "<tr><td>@flow</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>@flow weak</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>no flow</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>Total Files</td><td>3</td></tr>",
+  "</tfoot>",
+  "<tbody>",
+  "<tr data-status=\\"flow\\">
+<td>flow</td>
+<td>./a.js</td>
+</tr>",
+  "<tr data-status=\\"flow weak\\">
+<td>flow weak</td>
+<td>./b.js</td>
+</tr>",
+  "<tr data-status=\\"no flow\\">
+<td>no flow</td>
+<td>./c.js</td>
+</tr>",
+  "</tbody>",
+  "</table>",
+]
+`;
+
+exports[`printStatusReport asHTMLTable should print a summarized html-table report 1`] = `
+Array [
+  "<table>",
+  "<tr><td>@flow</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>@flow weak</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>no flow</td><td>1 (33.33%)</td></tr>",
+  "<tr><td>Total Files</td><td>3</td></tr>",
+  "</table>",
+]
+`;
+
+exports[`printStatusReport asHTMLTable should print an empty html-table report 1`] = `
+Array [
+  "<table>",
+  "<tfoot>",
+  "<tr><td>@flow</td><td>0</td></tr>",
+  "<tr><td>@flow weak</td><td>0</td></tr>",
+  "<tr><td>no flow</td><td>0</td></tr>",
+  "<tr><td>Total Files</td><td>0</td></tr>",
+  "</tfoot>",
+  "<tbody>",
+  "</tbody>",
+  "</table>",
+]
+`;
+
+exports[`printStatusReport asHTMLTable should print an html-table report with even percentages 1`] = `
+Array [
+  "<table>",
+  "<tfoot>",
+  "<tr><td>@flow</td><td>1 (50%)</td></tr>",
+  "<tr><td>@flow weak</td><td>1 (50%)</td></tr>",
+  "<tr><td>no flow</td><td>0 (0%)</td></tr>",
+  "<tr><td>Total Files</td><td>2</td></tr>",
+  "</tfoot>",
+  "<tbody>",
+  "<tr data-status=\\"flow\\">
+<td>flow</td>
+<td>./a.js</td>
+</tr>",
+  "<tr data-status=\\"flow weak\\">
+<td>flow weak</td>
+<td>./b.js</td>
+</tr>",
+  "</tbody>",
+  "</table>",
+]
+`;
+
+exports[`printStatusReport asJUnit should print a jUnit compatible report 1`] = `
 Array [
   "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"3\\" failures=\\"2\\" errors=\\"0\\">",
   "<testcase classname=\\"./a.js\\" name=\\"HasFlowStatus\\" time=\\"0\\" />",
@@ -10,42 +103,14 @@ Array [
 ]
 `;
 
-exports[`printStatusReport should print a simple csv report 1`] = `
+exports[`printStatusReport asJUnit should print a jUnit summary report 1`] = `
 Array [
-  "\\"flow\\", \\"./a.js\\"",
-  "\\"flow weak\\", \\"./b.js\\"",
-  "\\"no flow\\", \\"./c.js\\"",
+  "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"3\\" failures=\\"2\\" errors=\\"0\\">",
+  "</testsuite>",
 ]
 `;
 
-exports[`printStatusReport should print a simple html-table report 1`] = `
-Array [
-  "<table>",
-  "<tbody>",
-  "<tr data-status=\\"flow\\">
-        <td>flow</td>
-        <td>./a.js</td>
-      </tr>",
-  "<tr data-status=\\"flow weak\\">
-        <td>flow weak</td>
-        <td>./b.js</td>
-      </tr>",
-  "<tr data-status=\\"no flow\\">
-        <td>no flow</td>
-        <td>./c.js</td>
-      </tr>",
-  "</tbody>",
-  "<tfoot>",
-  "<tr><td>@flow</td><td>1 (33.33%)</td></tr>",
-  "<tr><td>@flow weak</td><td>1 (33.33%)</td></tr>",
-  "<tr><td>no flow</td><td>1 (33.33%)</td></tr>",
-  "<tr><td>Total Files</td><td>3</td></tr>",
-  "</tfoot>",
-  "</table>",
-]
-`;
-
-exports[`printStatusReport should print a simple text report 1`] = `
+exports[`printStatusReport asText should print a simple text report 1`] = `
 Array [
   "flow	./a.js",
   "flow weak	./b.js",
@@ -53,40 +118,11 @@ Array [
 ]
 `;
 
-exports[`printStatusReport should print an empty html-table report 1`] = `
+exports[`printStatusReport asText should print a summarized text report 1`] = `
 Array [
-  "<table>",
-  "<tbody>",
-  "</tbody>",
-  "<tfoot>",
-  "<tr><td>@flow</td><td>0</td></tr>",
-  "<tr><td>@flow weak</td><td>0</td></tr>",
-  "<tr><td>no flow</td><td>0</td></tr>",
-  "<tr><td>Total Files</td><td>0</td></tr>",
-  "</tfoot>",
-  "</table>",
-]
-`;
-
-exports[`printStatusReport should print an html-table report with even percentages 1`] = `
-Array [
-  "<table>",
-  "<tbody>",
-  "<tr data-status=\\"flow\\">
-        <td>flow</td>
-        <td>./a.js</td>
-      </tr>",
-  "<tr data-status=\\"flow weak\\">
-        <td>flow weak</td>
-        <td>./b.js</td>
-      </tr>",
-  "</tbody>",
-  "<tfoot>",
-  "<tr><td>@flow</td><td>1 (50%)</td></tr>",
-  "<tr><td>@flow weak</td><td>1 (50%)</td></tr>",
-  "<tr><td>no flow</td><td>0 (0%)</td></tr>",
-  "<tr><td>Total Files</td><td>2</td></tr>",
-  "</tfoot>",
-  "</table>",
+  "@flow 1 (33.33%)",
+  "@flow weak 1 (33.33%)",
+  "no flow 1 (33.33%)",
+  "Total Files 3",
 ]
 `;

--- a/src/__tests__/cli-test.js
+++ b/src/__tests__/cli-test.js
@@ -23,6 +23,7 @@ describe('cli', () => {
         flow_path: 'flow',
         include: ['**/*.js'],
         output: 'text',
+        summary_only: false,
         html_file: null,
         csv_file: null,
         junit_file: null,

--- a/src/__tests__/flow-test.js
+++ b/src/__tests__/flow-test.js
@@ -84,6 +84,7 @@ describe('genForceErrors', () => {
     flow_path: 'flow',
     include: [],
     output: 'text',
+    summary_only: false,
     html_file: null,
     csv_file: null,
     junit_file: null,

--- a/src/__tests__/printStatusReport-test.js
+++ b/src/__tests__/printStatusReport-test.js
@@ -20,34 +20,64 @@ const BASIC_REPORT = [
 ];
 
 describe('printStatusReport', () => {
-  beforeEach(() => {
-    global.Date = jest.fn(() => ({
-      toISOString: () => '-mock date-',
-    }));
-    os.hostname = jest.fn(() => 'test-host');
+  describe('asText', () => {
+    it('should print a simple text report', () => {
+      expect(asText(BASIC_REPORT, false)).toMatchSnapshot();
+    });
+
+    it('should print a summarized text report', () => {
+      expect(asText(BASIC_REPORT, true)).toMatchSnapshot();
+    });
   });
 
-  it('should print a simple text report', () => {
-    expect(asText(BASIC_REPORT)).toMatchSnapshot();
+  describe('asCSV', () => {
+    it('should print a simple csv report', () => {
+      expect(asCSV(BASIC_REPORT, false)).toMatchSnapshot();
+    });
+
+    it('should print a summarized csv report', () => {
+      expect(asCSV(BASIC_REPORT, true)).toMatchSnapshot();
+    });
   });
-  it('should print a simple csv report', () => {
-    expect(asCSV(BASIC_REPORT)).toMatchSnapshot();
+
+  describe('asHTMLTable', () => {
+    it('should print a simple html-table report', () => {
+      expect(asHTMLTable(BASIC_REPORT, false)).toMatchSnapshot();
+    });
+
+    it('should print a summarized html-table report', () => {
+      expect(asHTMLTable(BASIC_REPORT, true)).toMatchSnapshot();
+    });
+
+    it('should print an empty html-table report', () => {
+      const report = [];
+      expect(asHTMLTable(report, false)).toMatchSnapshot();
+    });
+
+    it('should print an html-table report with even percentages', () => {
+      const report = [
+        {status: 'flow', file: './a.js'},
+        {status: 'flow weak', file: './b.js'},
+      ];
+      expect(asHTMLTable(report, false)).toMatchSnapshot();
+    });
   });
-  it('should print a simple html-table report', () => {
-    expect(asHTMLTable(BASIC_REPORT)).toMatchSnapshot();
-  });
-  it('should print an empty html-table report', () => {
-    const report = [];
-    expect(asHTMLTable(report)).toMatchSnapshot();
-  });
-  it('should print an html-table report with even percentages', () => {
-    const report = [
-      {status: 'flow', file: './a.js'},
-      {status: 'flow weak', file: './b.js'},
-    ];
-    expect(asHTMLTable(report)).toMatchSnapshot();
-  });
-  it('should print a jUnit compatible report', () => {
-    expect(asJUnit(BASIC_REPORT)).toMatchSnapshot();
+
+  describe('asJUnit', () => {
+    beforeEach(() => {
+      // Needed for jUnit tests
+      global.Date = jest.fn(() => ({
+        toISOString: () => '-mock date-',
+      }));
+      os.hostname = jest.fn(() => 'test-host');
+    });
+
+    it('should print a jUnit compatible report', () => {
+      expect(asJUnit(BASIC_REPORT, false)).toMatchSnapshot();
+    });
+
+    it('should print a jUnit summary report', () => {
+      expect(asJUnit(BASIC_REPORT, true)).toMatchSnapshot();
+    });
   });
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -36,6 +36,7 @@ function resolveArgs(args: Args, defaults: Flags): Flags {
     flow_path: args.flow_path || defaults.flow_path,
     include: args.include || defaults.include,
     output: args.output || defaults.output,
+    summary_only: args.summary_only || defaults.summary_only,
     html_file: args.html_file || defaults.html_file,
     csv_file: args.csv_file || defaults.csv_file,
     junit_file: args.junit_file || defaults.junit_file,
@@ -89,26 +90,32 @@ function saveReportToFile(
   if (process.env.VERBOSE) {
     console.log(`Saving report as ${output} to ${filename}`);
   }
-  return write(filename, getReport(report, output).join("\n"));
+  return write(filename, getReport(report, output, false).join("\n"));
 }
 
-function getReport(report: StatusReport, output: OutputFormat): Array<string> {
+function getReport(
+  report: StatusReport,
+  output: OutputFormat,
+  summaryOnly: boolean,
+): Array<string> {
   switch (output) {
     case 'text':
-      return printStatusReportAsText(report);
+      return printStatusReportAsText(report, summaryOnly);
     case 'html-table':
-      return printStatusReportAsHTMLTable(report);
+      return printStatusReportAsHTMLTable(report, summaryOnly);
     case 'csv':
-      return printStatusReportAsCSV(report);
+      return printStatusReportAsCSV(report, summaryOnly);
     case 'junit':
-      return printStatusReportAsJUnit(report);
+      return printStatusReportAsJUnit(report, summaryOnly);
     default:
       throw new Error(`Invalid flag \`output\`. Found: ${JSON.stringify(output)}`);
   }
 }
 
 function printStatusReport(report: StatusReport, flags: Flags): StatusReport {
-  getReport(report, flags.output).map((line) => console.log(line));
+  getReport(report, flags.output, flags.summary_only).map(
+    (line) => console.log(line)
+  );
 
   const noFlowFiles = report.filter((entry) => entry.status == 'no flow');
   const weakFlowFiles = report.filter((entry) => entry.status == 'flow weak');

--- a/src/parser.js
+++ b/src/parser.js
@@ -34,6 +34,13 @@ export default function getParser(): ArgumentParser {
     },
   );
   parser.addArgument(
+    ['--summary-only'],
+    {
+      action: 'storeTrue',
+      help: `Output just the summary data, skipping the long list of files. Does not apply to saved file output. ${printDefault(DEFAULT_FLAGS.summary_only)} `,
+    },
+  );
+  parser.addArgument(
     ['--html-file'],
     {
       action: 'store',

--- a/src/types.js
+++ b/src/types.js
@@ -3,6 +3,7 @@
  */
 
 export type OutputFormat = 'text' | 'html-table' | 'csv' | 'junit';
+
 export const OutputFormats = {
   text: 'text',
   'html-table': 'html-table',
@@ -17,6 +18,7 @@ export type Args = {
   flow_path?: string,
   include?: Array<string>,
   output?: OutputFormat,
+  summary_only?: boolean,
   html_file?: string,
   csv_file?: string,
   junit_file?: string,
@@ -30,6 +32,7 @@ export type Flags = {
   flow_path: string,
   include: string | Array<string>,
   output: OutputFormat,
+  summary_only: boolean,
   html_file: ?string,
   csv_file: ?string,
   junit_file: ?string,
@@ -43,6 +46,7 @@ export const DEFAULT_FLAGS: Flags = {
   flow_path: 'flow',
   include: ['**/*.js'],
   output: 'text',
+  summary_only: false,
   html_file: null,
   csv_file: null,
   junit_file: null,


### PR DESCRIPTION
This new flag controls the output that gets printed to the console, setting it will only print a summary instead of the full file list with all the annotation states listed.

You can set the flag on the cli with `--summary-only` or inside the package.json file with something like this:

```
{
  "flow-annotation-check": {
  	"summary_only": true
  }
}
```

This flag does not affect what gets saved directly into files (via the --html-file, --csv-file, or --junit-file flags). Those files will always have the full output which you can count & filter afterwards.