### PR TITLE
Add support for @flow strict-local as a synonym for @flow strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Current Version](https://img.shields.io/npm/v/flow-annotation-check.svg)](https://www.npmjs.com/package/flow-annotation-check) [![Build Status](https://travis-ci.org/ryan953/flow-annotation-check.svg?branch=master)](https://travis-ci.org/ryan953/flow-annotation-check) [![codecov](https://codecov.io/gh/ryan953/flow-annotation-check/branch/master/graph/badge.svg)](https://codecov.io/gh/ryan953/flow-annotation-check)
  [![Greenkeeper badge](https://badges.greenkeeper.io/ryan953/flow-annotation-check.svg)](https://greenkeeper.io/)
 
-Verify the `@flow`, `@flow strict` and `@flow weak` annotations in your javascript files.
+Verify the `@flow`, `@flow strict`, `@flow strict-local` and `@flow weak` annotations in your javascript files.
 
 Install with NPM:
 
@@ -41,7 +41,7 @@ type Config = {
   absolute: boolean,
 };
 
-type FlowStatus = 'flow' | 'flow weak' | 'no flow';
+type FlowStatus = 'flow' | 'flow strict' | 'flow strict-local' | 'flow weak' | 'no flow';
 
 type FileReport = {
   file: string,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "exclude": [
       "src/__tests__/fixtures/comment-blocks-10.js",
       "src/__tests__/fixtures/comment-statement-10.js",
-      "src/__tests__/fixtures/no-comments.js"
+      "src/__tests__/fixtures/no-comments.js",
+      "src/__tests__/fixtures/flow-weak.js"
     ]
   },
   "flow-coverage-report": {

--- a/src/__tests__/__snapshots__/printStatusReport-test.js.snap
+++ b/src/__tests__/__snapshots__/printStatusReport-test.js.snap
@@ -3,6 +3,7 @@
 exports[`printStatusReport asCSV should print a simple csv report 1`] = `
 Array [
   "\\"flow strict\\", \\"./s.js\\"",
+  "\\"flow strict-local\\", \\"./sl.js\\"",
   "\\"flow\\", \\"./a.js\\"",
   "\\"flow weak\\", \\"./b.js\\"",
   "\\"no flow\\", \\"./c.js\\"",
@@ -12,14 +13,16 @@ Array [
 exports[`printStatusReport asCSV should print a summarized csv report 1`] = `
 Array [
   "\\"flow strict\\", \\"./s.js\\"",
+  "\\"flow strict-local\\", \\"./sl.js\\"",
   "\\"flow\\", \\"./a.js\\"",
   "\\"flow weak\\", \\"./b.js\\"",
   "\\"no flow\\", \\"./c.js\\"",
-  "\\"@flow\\", \\"1 (25%)\\"",
-  "\\"@flow strict\\", \\"1 (25%)\\"",
-  "\\"@flow weak\\", \\"1 (25%)\\"",
-  "\\"no flow\\", \\"1 (25%)\\"",
-  "\\"Total Files\\", \\"4\\"",
+  "\\"@flow\\", \\"1 (20%)\\"",
+  "\\"@flow strict\\", \\"1 (20%)\\"",
+  "\\"@flow strict-local\\", \\"1 (20%)\\"",
+  "\\"@flow weak\\", \\"1 (20%)\\"",
+  "\\"no flow\\", \\"1 (20%)\\"",
+  "\\"Total Files\\", \\"5\\"",
 ]
 `;
 
@@ -30,6 +33,10 @@ Array [
   "<tr data-status=\\"flow strict\\">
 <td>flow strict</td>
 <td>./s.js</td>
+</tr>",
+  "<tr data-status=\\"flow strict-local\\">
+<td>flow strict-local</td>
+<td>./sl.js</td>
 </tr>",
   "<tr data-status=\\"flow\\">
 <td>flow</td>
@@ -52,16 +59,21 @@ exports[`printStatusReport asHTMLTable should print a summarized html-table repo
 Array [
   "<table>",
   "<tfoot>",
-  "<tr><td>@flow</td><td>1 (25%)</td></tr>",
-  "<tr><td>@flow strict</td><td>1 (25%)</td></tr>",
-  "<tr><td>@flow weak</td><td>1 (25%)</td></tr>",
-  "<tr><td>no flow</td><td>1 (25%)</td></tr>",
-  "<tr><td>Total Files</td><td>4</td></tr>",
+  "<tr><td>@flow</td><td>1 (20%)</td></tr>",
+  "<tr><td>@flow strict</td><td>1 (20%)</td></tr>",
+  "<tr><td>@flow strict-local</td><td>1 (20%)</td></tr>",
+  "<tr><td>@flow weak</td><td>1 (20%)</td></tr>",
+  "<tr><td>no flow</td><td>1 (20%)</td></tr>",
+  "<tr><td>Total Files</td><td>5</td></tr>",
   "</tfoot>",
   "<tbody>",
   "<tr data-status=\\"flow strict\\">
 <td>flow strict</td>
 <td>./s.js</td>
+</tr>",
+  "<tr data-status=\\"flow strict-local\\">
+<td>flow strict-local</td>
+<td>./sl.js</td>
 </tr>",
   "<tr data-status=\\"flow\\">
 <td>flow</td>
@@ -97,8 +109,16 @@ Array [
 <td>flow</td>
 <td>./a.js</td>
 </tr>",
+  "<tr data-status=\\"flow strict\\">
+<td>flow strict</td>
+<td>./s.js</td>
+</tr>",
   "<tr data-status=\\"flow weak\\">
 <td>flow weak</td>
+<td>./b.js</td>
+</tr>",
+  "<tr data-status=\\"no flow\\">
+<td>no flow</td>
 <td>./b.js</td>
 </tr>",
   "</tbody>",
@@ -108,8 +128,9 @@ Array [
 
 exports[`printStatusReport asJUnit should print a jUnit compatible report 1`] = `
 Array [
-  "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"4\\" failures=\\"3\\" errors=\\"0\\">",
+  "<testsuite name=\\"flow-annotation-check\\" timestamp=\\"-mock date-\\" time=\\"0\\" hostname=\\"test-host\\" tests=\\"5\\" failures=\\"2\\" errors=\\"0\\">",
   "<testcase classname=\\"./s.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">Status is \\"flow strict\\"</failure></testcase>",
+  "<testcase classname=\\"./sl.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">Status is \\"flow strict-local\\"</failure></testcase>",
   "<testcase classname=\\"./a.js\\" name=\\"HasFlowStatus\\" time=\\"0\\" />",
   "<testcase classname=\\"./b.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasFlowWeakStatus\\">Status is \\"flow weak\\"</failure></testcase>",
   "<testcase classname=\\"./c.js\\" name=\\"HasFlowStatus\\" time=\\"0\\"><failure type=\\"HasNoneStatus\\">Status is \\"no flow\\"</failure></testcase>",
@@ -120,6 +141,7 @@ Array [
 exports[`printStatusReport asText should print a simple text report 1`] = `
 Array [
   "flow strict	./s.js",
+  "flow strict-local	./sl.js",
   "flow	./a.js",
   "flow weak	./b.js",
   "no flow	./c.js",
@@ -129,13 +151,15 @@ Array [
 exports[`printStatusReport asText should print a summarized text report 1`] = `
 Array [
   "flow strict	./s.js",
+  "flow strict-local	./sl.js",
   "flow	./a.js",
   "flow weak	./b.js",
   "no flow	./c.js",
-  "@flow 1 (25%)",
-  "@flow strict 1 (25%)",
-  "@flow weak 1 (25%)",
-  "no flow 1 (25%)",
-  "Total Files 4",
+  "@flow 1 (20%)",
+  "@flow strict 1 (20%)",
+  "@flow strict-local 1 (20%)",
+  "@flow weak 1 (20%)",
+  "no flow 1 (20%)",
+  "Total Files 5",
 ]
 `;

--- a/src/__tests__/fixtures/flow-strict-local.flow.js
+++ b/src/__tests__/fixtures/flow-strict-local.flow.js
@@ -1,0 +1,6 @@
+/*
+ * @flow strict-local
+ */
+
+// $FlowExpectedTestFailure
+const name: string = null;

--- a/src/__tests__/fixtures/flow-weak.js
+++ b/src/__tests__/fixtures/flow-weak.js
@@ -1,0 +1,6 @@
+/*
+ * @flow weak
+ */
+
+// $FlowExpectedTestFailure
+const name: string = null;

--- a/src/__tests__/flow-test.js
+++ b/src/__tests__/flow-test.js
@@ -9,6 +9,7 @@ import {genCheckFlowStatus, genForceErrors} from '../flow';
 
 const flowDetectedFixtures = [
   {status: 'flow strict', file: './fixtures/flow-strict.flow.js'},
+  {status: 'flow strict-local', file: './fixtures/flow-strict-local.flow.js'},
   {status: 'flow', file: './fixtures/comment-blocks-09.flow.js'},
   {status: 'flow', file: './fixtures/comment-single-block-09.flow.js'},
   {status: 'flow', file: './fixtures/comment-single-block-10.flow.js'},
@@ -26,6 +27,7 @@ const flowFailedFixtures = [
   {status: 'no flow', file: './fixtures/comment-blocks-10.js'},
   {status: 'no flow', file: './fixtures/comment-statement-10.js'},
   {status: 'no flow', file: './fixtures/no-comments.js'},
+  {status: 'flow weak', file: './fixtures/flow-weak.js'},
 ];
 const magicStringFixtures = [
   {status: 'flow', file: './fixtures/use-babel-block.flow.js'},
@@ -74,6 +76,7 @@ describe('genForceErrors', () => {
 
     switch (fixture.status) {
       case 'flow strict':
+      case 'flow strict-local':
       case 'flow':
       case 'flow weak':
         it(`should list ${fixture.file} because flow checks it`, () => {

--- a/src/__tests__/flowStatusFilter-test.js
+++ b/src/__tests__/flowStatusFilter-test.js
@@ -8,31 +8,38 @@ import flowStatusFilter from '../flowStatusFilter';
 
 const BASIC_REPORT = [
   {status: 'flow strict', file: './s.js'},
+  {status: 'flow strict-local', file: './sl.js'},
   {status: 'flow', file: './a.js'},
   {status: 'flow weak', file: './b.js'},
   {status: 'no flow', file: './c.js'},
 ];
 
 describe('flowStatusFilter', () => {
+  it('should return all things when there is a weird status name', () => {
+    // $FlowFixMe: Expected error with foobar input
+    expect(BASIC_REPORT.filter(flowStatusFilter('foobar', false))).toHaveLength(5);
+    // $FlowFixMe: Expected error with foobar input
+    expect(BASIC_REPORT.filter(flowStatusFilter('foobar', true))).toHaveLength(5);
+  });
   it('should keep all entries with the `all` filter', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('all', false))).toHaveLength(4);
+    expect(BASIC_REPORT.filter(flowStatusFilter('all', false))).toHaveLength(5);
   });
 
   it('should remove all entries with the `none` filter', () => {
     expect(BASIC_REPORT.filter(flowStatusFilter('none', false))).toHaveLength(0);
   });
 
-  it('should keep only the flow-strict file when flowstrict is used', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', false))).toHaveLength(1);
-    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', true))).toHaveLength(1);
+  it('should keep only the flow-strict & flow-strict-local files when flowstrict is used', () => {
+    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', false))).toHaveLength(2);
+    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', true))).toHaveLength(2);
   });
 
-  it('should keep only the flow and flow-strict files when allowWeak is false', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('flow', false))).toHaveLength(2);
+  it('should keep only the flow, flow-strict & flow-strict-local files when allowWeak is false', () => {
+    expect(BASIC_REPORT.filter(flowStatusFilter('flow', false))).toHaveLength(3);
   });
 
-  it('should keep the flow, flow-strict and flow-weak files when allowWeak is true', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('flow', true))).toHaveLength(3);
+  it('should keep the flow, flow-strict, flow-strict-local and flow-weak files when allowWeak is true', () => {
+    expect(BASIC_REPORT.filter(flowStatusFilter('flow', true))).toHaveLength(4);
   });
 
   it('should always only keep flow-weak files', () => {

--- a/src/__tests__/isValidFlowStatus-test.js
+++ b/src/__tests__/isValidFlowStatus-test.js
@@ -13,9 +13,12 @@ function assertFixture(fixture) {
 }
 
 describe('isValidFlowStatus', () => {
+  // 'no flow' has it's own tests
   const passThruFixtures = [
     {status: 'flow strict', fileErrored: false, expected: false},
     {status: 'flow strict', fileErrored: true, expected: true},
+    {status: 'flow strict-local', fileErrored: false, expected: false},
+    {status: 'flow strict-local', fileErrored: true, expected: true},
     {status: 'flow', fileErrored: false, expected: false},
     {status: 'flow', fileErrored: true, expected: true},
     {status: 'flow weak', fileErrored: false, expected: false},

--- a/src/__tests__/printStatusReport-test.js
+++ b/src/__tests__/printStatusReport-test.js
@@ -15,6 +15,7 @@ import os from 'os';
 
 const BASIC_REPORT = [
   {status: 'flow strict', file: './s.js'},
+  {status: 'flow strict-local', file: './sl.js'},
   {status: 'flow', file: './a.js'},
   {status: 'flow weak', file: './b.js'},
   {status: 'no flow', file: './c.js'},
@@ -80,7 +81,9 @@ describe('printStatusReport', () => {
     it('should print an html-table report with even percentages', () => {
       const report = [
         {status: 'flow', file: './a.js'},
+        {status: 'flow strict', file: './s.js'},
         {status: 'flow weak', file: './b.js'},
+        {status: 'no flow', file: './b.js'},
       ];
       expect(asHTMLTable(report, false, returnTrue)).toMatchSnapshot();
     });

--- a/src/flow.js
+++ b/src/flow.js
@@ -32,6 +32,7 @@ type FlowCheckResult = {
 
 const FLOW_MODE = {
   FLOW_STRICT: 'flow strict',
+  FLOW_STRICT_LOCAL: 'flow strict-local',
   FLOW: 'flow',
   FLOW_WEAK: 'flow weak',
   NO_FLOW: 'no flow',
@@ -44,6 +45,8 @@ function statusFromLines(lines: Array<string>): ?FlowStatus {
     const nextWord = words[nextPosition];
     if (nextWord === 'strict') {
       return FLOW_MODE.FLOW_STRICT;
+    } else if (nextWord === 'strict-local') {
+      return FLOW_MODE.FLOW_STRICT_LOCAL;
     } else if (nextWord === 'weak') {
       return FLOW_MODE.FLOW_WEAK;
     } else if (nextPosition) {

--- a/src/flowStatusFilter.js
+++ b/src/flowStatusFilter.js
@@ -17,9 +17,12 @@ export default function makeStatusFilter(
       case 'all':
         return true;
       case 'flow':
+        const isFlowOrBetter = entry.status === 'flow strict'
+          || entry.status === 'flow strict-local'
+          || entry.status === 'flow';
         return allowWeak
-          ? entry.status === 'flow strict' || entry.status === 'flow' || entry.status === 'flow weak'
-          : entry.status === 'flow strict' || entry.status === 'flow' ;
+          ? isFlowOrBetter || entry.status === 'flow weak'
+          : isFlowOrBetter;
       case 'noflow':
         return allowWeak
           ? entry.status === 'no flow'
@@ -27,7 +30,7 @@ export default function makeStatusFilter(
       case 'flowweak':
         return entry.status === 'flow weak';
       case 'flowstrict':
-        return entry.status === 'flow strict';
+        return entry.status === 'flow strict' || entry.status === 'flow strict-local';
       case 'none':
         return false;
       default:

--- a/src/isValidFlowStatus.js
+++ b/src/isValidFlowStatus.js
@@ -13,6 +13,8 @@ function isValidFlowStatus(
   switch(status) {
     case 'flow strict':
       return threwError;
+    case 'flow strict-local':
+      return threwError;
     case 'flow':
       return threwError;
     case 'flow weak':

--- a/src/printStatusReport.js
+++ b/src/printStatusReport.js
@@ -41,6 +41,7 @@ export function asText(
     return lines.concat([
       `@flow ${countByStatus(report, 'flow')}`,
       `@flow strict ${countByStatus(report, 'flow strict')}`,
+      `@flow strict-local ${countByStatus(report, 'flow strict-local')}`,
       `@flow weak ${countByStatus(report, 'flow weak')}`,
       `no flow ${countByStatus(report, 'no flow')}`,
       `Total Files ${String(report.length)}`,
@@ -59,6 +60,7 @@ export function asHTMLTable(
     '<tfoot>',
     htmlPair('@flow', countByStatus(report, 'flow')),
     htmlPair('@flow strict', countByStatus(report, 'flow strict')),
+    htmlPair('@flow strict-local', countByStatus(report, 'flow strict-local')),
     htmlPair('@flow weak', countByStatus(report, 'flow weak')),
     htmlPair('no flow', countByStatus(report, 'no flow')),
     htmlPair('Total Files', String(report.length)),
@@ -96,6 +98,7 @@ export function asCSV(
     return lines.concat([
       `"@flow", "${countByStatus(report, 'flow')}"`,
       `"@flow strict", "${countByStatus(report, 'flow strict')}"`,
+      `"@flow strict-local", "${countByStatus(report, 'flow strict-local')}"`,
       `"@flow weak", "${countByStatus(report, 'flow weak')}"`,
       `"no flow", "${countByStatus(report, 'no flow')}"`,
       `"Total Files", "${String(report.length)}"`,
@@ -112,7 +115,11 @@ export function asJUnit(
   const date = (new Date()).toISOString();
   const host = os.hostname();
   const tests = report.length;
-  const failures = report.length - report.filter((entry) => entry.status === 'flow').length;
+  const failures = report.length - report.filter(
+    (entry) => entry.status === 'flow'
+      || entry.status === 'flow strict'
+      || entry.status === 'flow strict-local'
+  ).length;
 
   return [
     `<testsuite name="flow-annotation-check" timestamp="${date}" time="0" hostname="${host}" tests="${tests}" failures="${failures}" errors="0">`,

--- a/src/types.js
+++ b/src/types.js
@@ -69,7 +69,7 @@ export const DEFAULT_FLAGS: Flags = {
   root: '.',
 };
 
-export type FlowStatus = 'flow strict' | 'flow' | 'flow weak' | 'no flow';
+export type FlowStatus = 'flow strict' | 'flow strict-local' | 'flow' | 'flow weak' | 'no flow';
 
 export type StatusEntry = {
   file: string,


### PR DESCRIPTION
This adds support for `@flow strict-local`. `@flow strict` and `@flow strict-local` are split out in all reports, so you can see exactly what's in your project. Also, `@flow strict-local` is added as a synonym to `--list-files flowstrict` so upgrades can be smooth. For example, if everything is strict or strict-local than you're well covered.

Fixes #55 

Read more about `@flow strict` and `@flow strict-local` here: https://flow.org/en/docs/strict/#toc-strict-local.
