### PR TITLE
Swap node 7 for 9, and be explicit about testing node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: node_js
 
 node_js:
   - node
+  - 10
+  - 9
   - 8
-  - 7
   - 6
   - 4
 


### PR DESCRIPTION
Increase node version coverage by explicitly testing node v9 and v10.