### PR TITLE
Drop support for node <8 and 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ language: node_js
 node_js:
   - node
   - 10
-  - 9
   - 8
-  - 6
-  - 4
 
 cache: yarn
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # flow-annotation-check
 
-[![Current Version](https://img.shields.io/npm/v/flow-annotation-check.svg)](https://www.npmjs.com/package/flow-annotation-check) [![Build Status](https://travis-ci.org/ryan953/flow-annotation-check.svg?branch=master)](https://travis-ci.org/ryan953/flow-annotation-check) [![codecov](https://codecov.io/gh/ryan953/flow-annotation-check/branch/master/graph/badge.svg)](https://codecov.io/gh/ryan953/flow-annotation-check)
+[![Current Version](https://img.shields.io/npm/v/flow-annotation-check.svg)](https://www.npmjs.com/package/flow-annotation-check)
+
+![node](https://img.shields.io/node/v/flow-annotation-check.svg) [![Build Status](https://travis-ci.org/ryan953/flow-annotation-check.svg?branch=master)](https://travis-ci.org/ryan953/flow-annotation-check) [![codecov](https://codecov.io/gh/ryan953/flow-annotation-check/branch/master/graph/badge.svg)](https://codecov.io/gh/ryan953/flow-annotation-check)
  [![Greenkeeper badge](https://badges.greenkeeper.io/ryan953/flow-annotation-check.svg)](https://greenkeeper.io/)
 
 Verify the `@flow`, `@flow strict`, `@flow strict-local` and `@flow weak` annotations in your javascript files.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "bugs": "https://github.com/ryan953/flow-annotation-check/issues",
   "main": "./lib/flow-annotation-check.js",
+  "engines": {
+    "node" : "^8 || >=10"
+  },
   "bin": {
     "flow-annotation-check": "./bin/flow-annotation-check.js"
   },


### PR DESCRIPTION
Node 8 is the current LTS release, with 6 in maintenance mode and 4 being end-of-life since 2018-04-30.

See https://github.com/nodejs/Release