### PR TITLE
 Add a `--summary-file` output flag for easy snippet reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The common settings you will use are:
 * `-x`, `--exclude`  Glob for files to exclude. Can be set multiple times.
 * `-a`, `--absolute` Report absolute path names. The default is to report only filenames.
 * `-o`, `--output`   Choose from either `text`, `csv`, `junit`, or `html` format.
+* `--show-summary`   Include a summary of the data in the `--output` stream, does not apply to `junit` format.
 
 Setting `--exclude` will override the defaults. So don't forget to ignore `node_modules/**/*.js` in addition to project specific folders.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The `junit` option prints an xml report suitable to be consumed by CI tools like
 
 The `html-table` option prints an opening and closing `<table>` tag with two columns of data. Each row contains a `data-status` attribute which can be useful for styling. There is a summary of the rows inside the `<tfoot>` element. This does not print a full, valid, html page but it is possible to render it directly. This option, with some custom CSS, could be used as part of a dashboard where only the names of the non-flow files are listed.
 
-In addition to the `--output` flag there are other flags that will return the report in different formats and save it directly to a file for you. You can set `--html-file`, `--csv-file` or `--junit-file` and each one will create a file containing the respective report. This is useful for getting the report in multiple formats at the same time.
+In addition to the `--output` flag there are other flags that will return the report in different formats and save it directly to a file for you. You can set `--html-file`, `--csv-file`, `--junit-file` or `--summary-file` and each one will create a file containing the respective report. This is useful for getting the report in multiple formats at the same time. Try them all at once!
 
 For example, it is desirable for CI logs to not have any extra markup and use the default `text` format with the `-o` flag. But at the same time possible to use the `--junit-file` flag to feed some data into jenkins for tracking over time.
 

--- a/src/__tests__/__snapshots__/parser-test.js.snap
+++ b/src/__tests__/__snapshots__/parser-test.js.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getParser should print the help message 1`] = `
-"usage: child.js [-h] [-v] [-f FLOW_PATH] [-o {text,html-table,csv,junit}]
-                [--show-summary] [--summary-only]
+"usage: child.js [-h] [-v] [-f FLOW_PATH]
+                [-o {text,html-table,csv,junit,summary}] [--show-summary]
+                [--summary-only]
                 [--list-files {all,flow,flowstrict,noflow,flowweak,none}]
                 [--html-file HTML_FILE] [--csv-file CSV_FILE]
-                [--junit-file JUNIT_FILE] [-a] [--allow-weak] [-i INCLUDE]
-                [-x EXCLUDE] [--validate]
+                [--junit-file JUNIT_FILE] [--summary-file SUMMARY_FILE] [-a]
+                [--allow-weak] [-i INCLUDE] [-x EXCLUDE] [--validate]
                 [root]
 
 Positional arguments:
@@ -18,7 +19,7 @@ Optional arguments:
   -v, --version         Show program's version number and exit.
   -f FLOW_PATH, --flow-path FLOW_PATH
                         The path to the flow command. (default: \`\\"flow\\"\`)
-  -o {text,html-table,csv,junit}, --output {text,html-table,csv,junit}
+  -o {text,html-table,csv,junit,summary}, --output {text,html-table,csv,junit,summary}
                         Output format for status/filename pairs. (default: 
                         \`\\"text\\"\`)
   --show-summary        Include summary data. Does not apply to saved file 
@@ -37,6 +38,9 @@ Optional arguments:
   --junit-file JUNIT_FILE
                         Save jUnit output directly into JUNIT_FILE. (default: 
                         \`null\`)
+  --summary-file SUMMARY_FILE
+                        Save a text-format summary of the report into 
+                        SUMMARY_FILE. (default: \`null\`)
   -a, --absolute        Report absolute path names. (default: \`false\`)
   --allow-weak          Consider \`@flow weak\` as a accepable annotation. See 
                         https://flowtype.org/docs/existing.html#weak-mode for 

--- a/src/__tests__/cli-test.js
+++ b/src/__tests__/cli-test.js
@@ -29,6 +29,7 @@ describe('cli', () => {
         html_file: null,
         csv_file: null,
         junit_file: null,
+        summary_file: null,
         root: path.resolve(path.join(__dirname, '../..')),
       });
     });

--- a/src/__tests__/flow-test.js
+++ b/src/__tests__/flow-test.js
@@ -68,6 +68,7 @@ describe('genForceErrors', () => {
     html_file: null,
     csv_file: null,
     junit_file: null,
+    summary_file: null,
     root: '.',
   };
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -27,6 +27,7 @@ import {
   asHTMLTable as printStatusReportAsHTMLTable,
   asCSV as printStatusReportAsCSV,
   asJUnit as printStatusReportAsJUnit,
+  asSummary as printStatusReportSummary,
 } from './printStatusReport';
 
 
@@ -52,6 +53,7 @@ function resolveArgs(args: Args, defaults: Flags): Flags {
     html_file: args.html_file || defaults.html_file, // flowlint-line sketchy-null-string:off
     csv_file: args.csv_file || defaults.csv_file, // flowlint-line sketchy-null-string:off
     junit_file: args.junit_file || defaults.junit_file, // flowlint-line sketchy-null-string:off
+    summary_file: args.summary_file || defaults.summary_file, // flowlint-line sketchy-null-string:off
     root: path.resolve(args.root || defaults.root), // flowlint-line sketchy-null-string:off
   };
 }
@@ -84,6 +86,9 @@ function main(flags: Flags): void {
             : null,
           flags.junit_file // flowlint-line sketchy-null-string:off
             ? saveReportToFile(flags.junit_file, report, 'junit')
+            : null,
+          flags.summary_file // flowlint-line sketchy-null-string:off
+            ? saveReportToFile(flags.summary_file, report, 'summary')
             : null,
         ]))
         .catch((error) => {
@@ -123,6 +128,8 @@ function getReport(
       return printStatusReportAsCSV(report, showSummary, filter);
     case 'junit':
       return printStatusReportAsJUnit(report, filter);
+    case 'summary':
+      return printStatusReportSummary(report);
     default:
       throw new Error(`Invalid flag \`output\`. Found: ${JSON.stringify(output)}`);
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -78,6 +78,13 @@ export default function getParser(): ArgumentParser {
     },
   );
   parser.addArgument(
+    ['--summary-file'],
+    {
+      action: 'store',
+      help: `Save a text-format summary of the report into SUMMARY_FILE. ${printDefault(DEFAULT_FLAGS.summary_file)} `,
+    }
+  );
+  parser.addArgument(
     ['-a', '--absolute'],
     {
       action: 'storeTrue',

--- a/src/printStatusReport.js
+++ b/src/printStatusReport.js
@@ -28,6 +28,19 @@ function escapeXML(value: string): string {
     .replace(/'/g, '&#039;');
 }
 
+export function asSummary(
+  report: StatusReport,
+): Array<string> {
+  return [
+    `@flow ${countByStatus(report, 'flow')}`,
+    `@flow strict ${countByStatus(report, 'flow strict')}`,
+    `@flow strict-local ${countByStatus(report, 'flow strict-local')}`,
+    `@flow weak ${countByStatus(report, 'flow weak')}`,
+    `no flow ${countByStatus(report, 'no flow')}`,
+    `Total Files ${String(report.length)}`,
+  ];
+}
+
 export function asText(
   report: StatusReport,
   showSummary: boolean,
@@ -37,18 +50,11 @@ export function asText(
     .filter(filter)
     .map((entry) => `${entry.status}\t${entry.file}`);
 
-  if (showSummary) {
-    return lines.concat([
-      `@flow ${countByStatus(report, 'flow')}`,
-      `@flow strict ${countByStatus(report, 'flow strict')}`,
-      `@flow strict-local ${countByStatus(report, 'flow strict-local')}`,
-      `@flow weak ${countByStatus(report, 'flow weak')}`,
-      `no flow ${countByStatus(report, 'no flow')}`,
-      `Total Files ${String(report.length)}`,
-    ]);
-  } else {
-    return lines;
-  }
+  return (
+    showSummary
+      ? lines.concat(asSummary(report))
+      : lines
+  );
 }
 
 export function asHTMLTable(

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-export type OutputFormat = 'text' | 'html-table' | 'csv' | 'junit';
+export type OutputFormat = 'text' | 'html-table' | 'csv' | 'junit' | 'summary';
 export type VisibileStatusType = 'all' | 'flow' | 'noflow' | 'flowweak' | 'flowstrict' | 'none';
 
 export const OutputFormats = {
@@ -10,6 +10,7 @@ export const OutputFormats = {
   'html-table': 'html-table',
   csv: 'csv',
   junit: 'junit',
+  summary: 'summary',
 };
 
 export const VisibleStatusTypes = {
@@ -34,6 +35,7 @@ export type Args = {
   html_file?: string,
   csv_file?: string,
   junit_file?: string,
+  summary_file?: string,
   root?: string,
 };
 
@@ -50,6 +52,7 @@ export type Flags = {
   html_file: ?string,
   csv_file: ?string,
   junit_file: ?string,
+  summary_file: ?string,
   root: string,
 };
 
@@ -66,6 +69,7 @@ export const DEFAULT_FLAGS: Flags = {
   html_file: null,
   csv_file: null,
   junit_file: null,
+  summary_file: null,
   root: '.',
 };
 


### PR DESCRIPTION
I've a use-case where I want to automatically post just the summary data and it's gonna be easier if i can just output that instead of parsing it from the html or from the bottom of the stdout stream.

So we get the `--summary-file` flag which puts those six lines into their own file, along with any other files we might be outputting too.