### PR TITLE
Set the testEnvironment for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     ]
   },
   "jest": {
+    "testEnvironment": "node",
     "roots": [
       "src"
     ],


### PR DESCRIPTION
We're not running inside a browser, so let's make sure tests emulate node.