### PR TITLE
Refactor the StatusReportSummary into genReport()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import genReport, {genCheckFlowStatus, genValidate} from 'flow-annotation-check'
 
 The most useful public methods are:
 
-- `genReport(folder: string, config: Config): Promise<Array<FileReport>>`
+- `genReport(folder: string, config: Config): Promise<Report>`
 - `genCheckFlowStatus(flowPath: string, filePath: string): Promise<FlowStatus>`
 
 The types involved are:
@@ -47,9 +47,19 @@ type Config = {
 
 type FlowStatus = 'flow' | 'flow strict' | 'flow strict-local' | 'flow weak' | 'no flow';
 
-type FileReport = {
-  file: string,
-  status: FlowStatus,
+type Report = {
+  summary: {
+    flow: number,
+    flowstrict: number,
+    flowstrictlocal: number,
+    flowweak: number,
+    noflow: number,
+    total: number,
+  },
+  files: Array<{
+    file: string,
+    status: FlowStatus,
+  }>,
 };
 ```
 
@@ -69,8 +79,8 @@ genReport(
     exclude: ['**/*.coffee'],
     absolute: true,
   }
-).then((entries) => {
-  entries.forEach((entry) => {
+).then((report) => {
+  report.files.forEach((entry) => {
     console.log(entry.status + "\t" + entry.file);
   });
 });
@@ -136,8 +146,8 @@ The common settings to use are:
 * `-i`, `--include`  [Glob](https://github.com/isaacs/node-glob) for files to include. Can be set multiple times.
 * `-x`, `--exclude`  [Glob](https://github.com/isaacs/node-glob) for files to exclude. Can be set multiple times.
 * `-a`, `--absolute` Report absolute path names. The default is to report only filenames.
-* `-o`, `--output`   Choose from either `text`, `csv`, `junit`, or `html` format.
-* `--show-summary`   Include a summary of the data in the `--output` stream. Does not apply to `junit` format.
+* `-o`, `--output`   Choose from either `text`, `csv`, `junit`, `json` or `html` format.
+* `--show-summary`   Include a summary of the data in the `--output` stream. Summary is never included in the `junit` format, and always in the `json` format.
 
 Setting `--exclude` will override the defaults! Don't forget to ignore `node_modules/**/*.js` in addition to project specific folders.
 
@@ -163,9 +173,11 @@ The `csv` option prints a two column list of status value and filename with each
 
 The `junit` option prints an xml report suitable to be consumed by CI tools like Jenkins.
 
+The `json` option prints a json file with the return value of `genSummarizedReport()`, the `Report` type described above.
+
 The `html-table` option prints an opening and closing `<table>` tag with two columns of data. Each row contains a `data-status` attribute which can be useful for styling. There is a summary of the rows inside the `<tfoot>` element. This does not print a full, valid, html page but it is possible to render it directly. This option, with some custom CSS, could be used as part of a dashboard where only the names of the non-flow files are listed.
 
-In addition to the `--output` flag there are other flags that will return the report in different formats and save it directly to a file for you. You can set `--html-file`, `--csv-file`, `--junit-file` or `--summary-file` and each one will create a file containing the respective report. This is useful for getting the report in multiple formats at the same time. Try them all at once!
+In addition to the `--output` flag there are other flags that will return the report in different formats and save it directly to a file for you. You can set `--html-file`, `--csv-file`, `--junit-file`, `--json-file` or `--summary-file` and each one will create a file containing the respective report. This is useful for getting the report in multiple formats at the same time. Try them all at once!
 
 For example, it is desirable for CI logs to not have any extra markup and use the default `text` format with the `-o` flag. But at the same time possible to use the `--junit-file` flag to feed some data into jenkins for tracking over time.
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ npx flow-annotation-check ~/path/to/project
 Once installed you can import `flow-annotation-check` into your own module and have the checker return a list of files for you to further process.
 
 ```javascript
-import genReport, {genCheckFlowStatus, genValidate} from 'flow-annotation-check';
+import {genSummarizedReport, genCheckFlowStatus, genValidate} from 'flow-annotation-check';
 ```
 
 The most useful public methods are:
 
-- `genReport(folder: string, config: Config): Promise<Report>`
+- `genSummarizedReport(folder: string, config: Config): Promise<Report>`
 - `genCheckFlowStatus(flowPath: string, filePath: string): Promise<FlowStatus>`
 
 The types involved are:
@@ -63,16 +63,16 @@ type Report = {
 };
 ```
 
-#### genReport(folder, config)
+#### genSummarizedReport(folder, config)
 
-If you want to check a whole project at once, then call `genReport`. You can pass in the root folder, like `~/my-project/src` and then a configuration object with some glob strings to find your files. `genReport` will return a Promise that will resolve when all matching files have had their flow-status discovered.
+If you want to check a whole project at once, then call `genSummarizedReport`. You can pass in the root folder, like `~/my-project/src` and then a configuration object with some glob strings to find your files. `genSummarizedReport` will return a Promise that will resolve when all matching files have had their flow-status discovered.
 
 This is a convenience method to make working with globs and mapping over `genCheckFlowStatus` easier. Each file is tested serially in order to avoid setting really long timeouts that lock up the flow server.
 
 ```javascript
-import genReport from 'flow-annotation-check';
+import {genSummarizedReport} from 'flow-annotation-check';
 
-genReport(
+genSummarizedReport(
   '~/path/to/project',
   {
     include: ['**/*.js'],

--- a/src/__tests__/printStatusReport-test.js
+++ b/src/__tests__/printStatusReport-test.js
@@ -15,13 +15,34 @@ import {
 
 import os from 'os';
 
-const BASIC_REPORT = [
-  {status: 'flow strict', file: './s.js'},
-  {status: 'flow strict-local', file: './sl.js'},
-  {status: 'flow', file: './a.js'},
-  {status: 'flow weak', file: './b.js'},
-  {status: 'no flow', file: './c.js'},
-];
+const EMPTY_REPORT = {
+  summary: {
+    flow: 0,
+    flowstrict: 0,
+    flowstrictlocal: 0,
+    flowweak: 0,
+    noflow: 0,
+    total: 0,
+  },
+  files: [],
+}
+const BASIC_REPORT = {
+  summary: {
+    flow: 1,
+    flowstrict: 1,
+    flowstrictlocal: 1,
+    flowweak: 1,
+    noflow: 1,
+    total: 5,
+  },
+  files: [
+    {status: 'flow strict', file: './s.js'},
+    {status: 'flow strict-local', file: './sl.js'},
+    {status: 'flow', file: './a.js'},
+    {status: 'flow weak', file: './b.js'},
+    {status: 'no flow', file: './c.js'},
+  ],
+};
 
 const returnTrue = jest.fn();
 
@@ -48,7 +69,7 @@ describe('printStatusReport', () => {
 
     it('should filtered the report based on status', () => {
       asText(BASIC_REPORT, true, returnTrue);
-      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.length);
+      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.files.length);
     });
   });
 
@@ -63,7 +84,7 @@ describe('printStatusReport', () => {
 
     it('should filter the csv report', () => {
       asCSV(BASIC_REPORT, false, returnTrue);
-      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.length);
+      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.files.length);
     });
   });
 
@@ -78,21 +99,30 @@ describe('printStatusReport', () => {
 
     it('should filter the html-table report', () => {
       asHTMLTable(BASIC_REPORT, true, returnTrue);
-      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.length);
+      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.files.length);
     });
 
     it('should print an empty html-table report', () => {
-      const report = [];
-      expect(asHTMLTable(report, false, returnTrue)).toMatchSnapshot();
+      expect(asHTMLTable(EMPTY_REPORT, false, returnTrue)).toMatchSnapshot();
     });
 
     it('should print an html-table report with even percentages', () => {
-      const report = [
-        {status: 'flow', file: './a.js'},
-        {status: 'flow strict', file: './s.js'},
-        {status: 'flow weak', file: './b.js'},
-        {status: 'no flow', file: './b.js'},
-      ];
+      const report = {
+        summary: {
+          flow: 1,
+          flowstrict: 1,
+          flowstrictlocal: 0,
+          flowweak: 1,
+          noflow: 1,
+          total: 4,
+        },
+        files: [
+          {status: 'flow', file: './a.js'},
+          {status: 'flow strict', file: './s.js'},
+          {status: 'flow weak', file: './b.js'},
+          {status: 'no flow', file: './b.js'},
+        ],
+      };
       expect(asHTMLTable(report, false, returnTrue)).toMatchSnapshot();
     });
   });
@@ -112,7 +142,7 @@ describe('printStatusReport', () => {
 
     it('should filter the jUnit report', () => {
       asJUnit(BASIC_REPORT, returnTrue);
-      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.length);
+      expect(returnTrue).toHaveBeenCalledTimes(BASIC_REPORT.files.length);
     });
   });
 

--- a/src/__tests__/promisified-test.js
+++ b/src/__tests__/promisified-test.js
@@ -7,7 +7,15 @@
 jest.mock('child_process');
 jest.mock('fs');
 
-import {exec, execFile, stat, write, append, truncate} from '../promisified';
+import {
+  append,
+  asyncMap,
+  exec,
+  execFile,
+  stat,
+  truncate,
+  write,
+} from '../promisified';
 const childProcess = require('child_process');
 const fs = require('fs');
 
@@ -214,6 +222,22 @@ describe('promisified', () => {
       callbackArg('failed', 'foo bar');
 
       return promise;
+    });
+  });
+
+  describe('asyncMap', () => {
+    it('should map a list of things to promises', () => {
+      return expect(asyncMap(
+        [1, 2, 3],
+        (num) => Promise.resolve(num * 2)
+      )).resolves.toEqual([2, 4, 6]);
+    });
+
+    it('should return any rejections', () => {
+      return expect(asyncMap(
+        [true, false, true],
+        (b) => b ? Promise.resolve(true) : Promise.reject(false)
+      )).rejects.toEqual(false);
     });
   });
 

--- a/src/__tests__/summarizeReport-test.js
+++ b/src/__tests__/summarizeReport-test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+jest.mock('glob');
+
+import summarizeReport from '../summarizeReport';
+
+describe('summarizeReport', () => {
+  it('should count the files files', () => {
+    const files = [
+      {status: 'flow strict', file: './s.js'},
+      {status: 'flow strict-local', file: './sl.js'},
+      {status: 'flow', file: './a.js'},
+      {status: 'flow weak', file: './b.js'},
+      {status: 'no flow', file: './c.js'},
+    ];
+    expect(summarizeReport(files)).toEqual({
+      flow: 1,
+      flowstrict: 1,
+      flowstrictlocal: 1,
+      flowweak: 1,
+      noflow: 1,
+      total: files.length,
+    });
+  });
+
+  it('should count 0 when there are no files', () => {
+    expect(summarizeReport([])).toEqual({
+      flow: 0,
+      flowstrict: 0,
+      flowstrictlocal: 0,
+      flowweak: 0,
+      noflow: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ import type {EntryFilter} from './flowStatusFilter';
 import {DEFAULT_FLAGS} from './types';
 
 import flowStatusFilter from './flowStatusFilter';
-import genReport, {genValidate} from './flow-annotation-check';
+import {genSummarizedReport, genValidate} from './flow-annotation-check';
 import getParser from './parser';
 import loadPkg from 'load-pkg';
 import path from 'path';
@@ -77,7 +77,7 @@ function main(flags: Flags): void {
         });
       break;
     default:
-      genReport(flags.root, flags)
+      genSummarizedReport(flags.root, flags)
         .then((report) => printStatusReport(report, flags))
         .then((report) => Promise.all([
           flags.html_file // flowlint-line sketchy-null-string:off

--- a/src/cli.js
+++ b/src/cli.js
@@ -155,11 +155,11 @@ function printStatusReport(report: StatusReport, flags: Flags): StatusReport {
     (line) => console.log(line)
   );
 
-  const noFlowFiles = report.filter((entry) => entry.status == 'no flow');
-  const weakFlowFiles = report.filter((entry) => entry.status == 'flow weak');
+  const noFlowFiles = report.summary.noflow;
+  const weakFlowFiles = report.summary.flowweak;
   const failingFileCount = flags.allow_weak
-    ? noFlowFiles.length
-    : noFlowFiles.length + weakFlowFiles.length;
+    ? noFlowFiles
+    : noFlowFiles + weakFlowFiles;
   process.exitCode = failingFileCount ? 1 : 0;
 
   return report;

--- a/src/flow-annotation-check.js
+++ b/src/flow-annotation-check.js
@@ -43,7 +43,7 @@ function summarizeReport(
   };
 }
 
-function genReport(
+function genSummarizedReport(
   cwd: string,
   flags: Flags,
 ): Promise<StatusReport> {
@@ -63,6 +63,14 @@ function genReport(
       summary: summarizeReport(files),
       files: files,
     }))
+}
+
+function genReport(
+  cwd: string,
+  flags: Flags,
+): Promise<Array<StatusEntry>> {
+  return genSummarizedReport(cwd, flags)
+    .then((report) => report.files);
 }
 
 function genFilesWithErrors(
@@ -93,7 +101,7 @@ function coalesceReports(
 
 function genValidate(cwd: string, flags: Flags): Promise<ValidationReport> {
   return Promise.all([
-    genReport(cwd, flags),
+    genSummarizedReport(cwd, flags),
     genFilesWithErrors(cwd, flags),
   ]).then(([report, errorReport]) => {
     return coalesceReports(report, errorReport);
@@ -101,4 +109,4 @@ function genValidate(cwd: string, flags: Flags): Promise<ValidationReport> {
 }
 
 export default genReport;
-export {genCheckFlowStatus, genValidate};
+export {genSummarizedReport, genCheckFlowStatus, genValidate};

--- a/src/flow-annotation-check.js
+++ b/src/flow-annotation-check.js
@@ -16,25 +16,9 @@ import type {
 
 import globsToFileList from './globsToFileList';
 import isValidFlowStatus from './isValidFlowStatus';
+import summarizeReport from './summarizeReport';
 import {asyncMap} from './promisified';
 import {genCheckFlowStatus, genForceErrors} from './flow';
-
-function countByStatus(files: Array<StatusEntry>, status: FlowStatus): number {
-  return files.filter((entry) => entry.status === status).length;
-}
-
-function summarizeReport(
-  files: Array<StatusEntry>,
-): StatusReportSummary {
-  return {
-    flow: countByStatus(files, 'flow'),
-    flowstrict: countByStatus(files, 'flow strict'),
-    flowstrictlocal: countByStatus(files, 'flow strict-local'),
-    flowweak: countByStatus(files, 'flow weak'),
-    noflow: countByStatus(files, 'no flow'),
-    total: files.length,
-  };
-}
 
 function genSummarizedReport(
   cwd: string,

--- a/src/promisified.js
+++ b/src/promisified.js
@@ -91,7 +91,22 @@ function truncate(file: string, data: string | Buffer): Promise<void> {
   });
 }
 
+function asyncMap<I, T>(
+  items: Array<I>,
+  mapper: (item: I) => Promise<T>,
+): Promise<Array<T>> {
+  return items.reduce((prom, item) => {
+    return prom.then((arr) => {
+      return Promise.resolve(mapper(item)).then((result) => {
+        arr.push(result);
+        return arr;
+      })
+    });
+  }, Promise.resolve([]));
+}
+
 export {
+  asyncMap,
   escapeShell,
   exec,
   execFile,

--- a/src/summarizeReport.js
+++ b/src/summarizeReport.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+import type {
+  FlowStatus,
+  StatusEntry,
+  StatusReportSummary,
+} from './types';
+
+function countByStatus(files: Array<StatusEntry>, status: FlowStatus): number {
+  return files.filter((entry) => entry.status === status).length;
+}
+
+function summarizeReport(
+  files: Array<StatusEntry>,
+): StatusReportSummary {
+  return {
+    flow: countByStatus(files, 'flow'),
+    flowstrict: countByStatus(files, 'flow strict'),
+    flowstrictlocal: countByStatus(files, 'flow strict-local'),
+    flowweak: countByStatus(files, 'flow weak'),
+    noflow: countByStatus(files, 'no flow'),
+    total: files.length,
+  };
+}
+
+export default summarizeReport;

--- a/src/types.js
+++ b/src/types.js
@@ -91,6 +91,18 @@ export type ValidityEntry = {
   threwError: boolean,
 };
 
-export type StatusReport = Array<StatusEntry>;
+export type StatusReportSummary = {
+  flow: number,
+  flowstrict: number,
+  flowstrictlocal: number,
+  flowweak: number,
+  noflow: number,
+  total: number,
+};
+
+export type StatusReport = {
+  summary: StatusReportSummary,
+  files: Array<StatusEntry>,
+};
 export type ValidationReport = Array<ValidityEntry>;
 export type ErrorReport = Array<string>;


### PR DESCRIPTION
Centralize the summary building into the genReport() call. This should save a few extra filter() calls over all our files when we're output many formats. 

Also, update the README to include the new return values from genReport() and flow types.