### PR TITLE
Create --level flag and aliases

### DIFF
--- a/flow-typed/npm/jest_v22.x.x.js
+++ b/flow-typed/npm/jest_v22.x.x.js
@@ -1,6 +1,3 @@
-// flow-typed signature: 5960ed076fe29ecf92f57584d68acf98
-// flow-typed version: b2a49dc910/jest_v20.x.x/flow_>=v0.39.x
-
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -45,7 +42,7 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
    * will also be executed when the mock is called.
    */
   mockImplementation(
-    fn: (...args: TArguments) => TReturn,
+    fn: (...args: TArguments) => TReturn
   ): JestMockFn<TArguments, TReturn>,
   /**
    * Accepts a function that will be used as an implementation of the mock for
@@ -53,8 +50,13 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
    * calls produce different results.
    */
   mockImplementationOnce(
-    fn: (...args: TArguments) => TReturn,
+    fn: (...args: TArguments) => TReturn
   ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a string to use in test result output in place of "jest.fn()" to
+   * indicate which mock function is being referenced.
+   */
+  mockName(name: string): JestMockFn<TArguments, TReturn>,
   /**
    * Just a simple sugar function for returning `this`
    */
@@ -114,30 +116,372 @@ type JestPromiseType = {
 };
 
 /**
+ * Jest allows functions and classes to be used as test names in test() and
+ * describe()
+ */
+type JestTestName = string | Function;
+
+/**
  *  Plugin: jest-enzyme
  */
 type EnzymeMatchersType = {
   toBeChecked(): void,
   toBeDisabled(): void,
   toBeEmpty(): void,
+  toBeEmptyRender(): void,
   toBePresent(): void,
   toContainReact(element: React$Element<any>): void,
+  toExist(): void,
   toHaveClassName(className: string): void,
   toHaveHTML(html: string): void,
-  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveProp: ((propKey: string, propValue?: any) => void) & ((props: Object) => void),
   toHaveRef(refName: string): void,
-  toHaveState(stateKey: string, stateValue?: any): void,
-  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveState: ((stateKey: string, stateValue?: any) => void) & ((state: Object) => void),
+  toHaveStyle: ((styleKey: string, styleValue?: any) => void) & ((style: Object) => void),
   toHaveTagName(tagName: string): void,
   toHaveText(text: string): void,
   toIncludeText(text: string): void,
   toHaveValue(value: any): void,
   toMatchElement(element: React$Element<any>): void,
-  toMatchSelector(selector: string): void,
+  toMatchSelector(selector: string): void
+};
+
+// DOM testing library extensions https://github.com/kentcdodds/dom-testing-library#custom-jest-matchers
+type DomTestingLibraryType = {
+  toBeInTheDOM(): void,
+  toHaveTextContent(content: string): void,
+  toHaveAttribute(name: string, expectedValue?: string): void
+};
+
+// Jest JQuery Matchers: https://github.com/unindented/custom-jquery-matchers
+type JestJQueryMatchersType = {
+  toExist(): void,
+  toHaveLength(len: number): void,
+  toHaveId(id: string): void,
+  toHaveClass(className: string): void,
+  toHaveTag(tag: string): void,
+  toHaveAttr(key: string, val?: any): void,
+  toHaveProp(key: string, val?: any): void,
+  toHaveText(text: string | RegExp): void,
+  toHaveData(key: string, val?: any): void,
+  toHaveValue(val: any): void,
+  toHaveCss(css: {[key: string]: any}): void,
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBeHidden(): void,
+  toBeSelected(): void,
+  toBeVisible(): void,
+  toBeFocused(): void,
+  toBeInDom(): void,
+  toBeMatchedBy(sel: string): void,
+  toHaveDescendant(sel: string): void,
+  toHaveDescendantWithText(sel: string, text: string | RegExp): void
+};
+
+
+// Jest Extended Matchers: https://github.com/jest-community/jest-extended
+type JestExtendedMatchersType = {
+  /**
+     * Note: Currently unimplemented
+     * Passing assertion
+     *
+     * @param {String} message
+     */
+  //  pass(message: string): void;
+
+    /**
+     * Note: Currently unimplemented
+     * Failing assertion
+     *
+     * @param {String} message
+     */
+  //  fail(message: string): void;
+
+    /**
+     * Use .toBeEmpty when checking if a String '', Array [] or Object {} is empty.
+     */
+    toBeEmpty(): void;
+
+    /**
+     * Use .toBeOneOf when checking if a value is a member of a given Array.
+     * @param {Array.<*>} members
+     */
+    toBeOneOf(members: any[]): void;
+
+    /**
+     * Use `.toBeNil` when checking a value is `null` or `undefined`.
+     */
+    toBeNil(): void;
+
+    /**
+     * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
+     * @param {Function} predicate
+     */
+    toSatisfy(predicate: (n: any) => boolean): void;
+
+    /**
+     * Use `.toBeArray` when checking if a value is an `Array`.
+     */
+    toBeArray(): void;
+
+    /**
+     * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
+     * @param {Number} x
+     */
+    toBeArrayOfSize(x: number): void;
+
+    /**
+     * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+     * @param {Array.<*>} members
+     */
+    toIncludeAllMembers(members: any[]): void;
+
+    /**
+     * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
+     * @param {Array.<*>} members
+     */
+    toIncludeAnyMembers(members: any[]): void;
+
+    /**
+     * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
+     * @param {Function} predicate
+     */
+    toSatisfyAll(predicate: (n: any) => boolean): void;
+
+    /**
+     * Use `.toBeBoolean` when checking if a value is a `Boolean`.
+     */
+    toBeBoolean(): void;
+
+    /**
+     * Use `.toBeTrue` when checking a value is equal (===) to `true`.
+     */
+    toBeTrue(): void;
+
+    /**
+     * Use `.toBeFalse` when checking a value is equal (===) to `false`.
+     */
+    toBeFalse(): void;
+
+    /**
+     * Use .toBeDate when checking if a value is a Date.
+     */
+    toBeDate(): void;
+
+    /**
+     * Use `.toBeFunction` when checking if a value is a `Function`.
+     */
+    toBeFunction(): void;
+
+    /**
+     * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
+     *
+     * Note: Required Jest version >22
+     * Note: Your mock functions will have to be asynchronous to cause the timestamps inside of Jest to occur in a differentJS event loop, otherwise the mock timestamps will all be the same
+     *
+     * @param {Mock} mock
+     */
+    toHaveBeenCalledBefore(mock: JestMockFn<any, any>): void;
+
+    /**
+     * Use `.toBeNumber` when checking if a value is a `Number`.
+     */
+    toBeNumber(): void;
+
+    /**
+     * Use `.toBeNaN` when checking a value is `NaN`.
+     */
+    toBeNaN(): void;
+
+    /**
+     * Use `.toBeFinite` when checking if a value is a `Number`, not `NaN` or `Infinity`.
+     */
+    toBeFinite(): void;
+
+    /**
+     * Use `.toBePositive` when checking if a value is a positive `Number`.
+     */
+    toBePositive(): void;
+
+    /**
+     * Use `.toBeNegative` when checking if a value is a negative `Number`.
+     */
+    toBeNegative(): void;
+
+    /**
+     * Use `.toBeEven` when checking if a value is an even `Number`.
+     */
+    toBeEven(): void;
+
+    /**
+     * Use `.toBeOdd` when checking if a value is an odd `Number`.
+     */
+    toBeOdd(): void;
+
+    /**
+     * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
+     *
+     * @param {Number} start
+     * @param {Number} end
+     */
+    toBeWithin(start: number, end: number): void;
+
+    /**
+     * Use `.toBeObject` when checking if a value is an `Object`.
+     */
+    toBeObject(): void;
+
+    /**
+     * Use `.toContainKey` when checking if an object contains the provided key.
+     *
+     * @param {String} key
+     */
+    toContainKey(key: string): void;
+
+    /**
+     * Use `.toContainKeys` when checking if an object has all of the provided keys.
+     *
+     * @param {Array.<String>} keys
+     */
+    toContainKeys(keys: string[]): void;
+
+    /**
+     * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
+     *
+     * @param {Array.<String>} keys
+     */
+    toContainAllKeys(keys: string[]): void;
+
+    /**
+     * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
+     *
+     * @param {Array.<String>} keys
+     */
+    toContainAnyKeys(keys: string[]): void;
+
+    /**
+     * Use `.toContainValue` when checking if an object contains the provided value.
+     *
+     * @param {*} value
+     */
+    toContainValue(value: any): void;
+
+    /**
+     * Use `.toContainValues` when checking if an object contains all of the provided values.
+     *
+     * @param {Array.<*>} values
+     */
+    toContainValues(values: any[]): void;
+
+    /**
+     * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
+     *
+     * @param {Array.<*>} values
+     */
+    toContainAllValues(values: any[]): void;
+
+    /**
+     * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
+     *
+     * @param {Array.<*>} values
+     */
+    toContainAnyValues(values: any[]): void;
+
+    /**
+     * Use `.toContainEntry` when checking if an object contains the provided entry.
+     *
+     * @param {Array.<String, String>} entry
+     */
+    toContainEntry(entry: [string, string]): void;
+
+    /**
+     * Use `.toContainEntries` when checking if an object contains all of the provided entries.
+     *
+     * @param {Array.<Array.<String, String>>} entries
+     */
+    toContainEntries(entries: [string, string][]): void;
+
+    /**
+     * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
+     *
+     * @param {Array.<Array.<String, String>>} entries
+     */
+    toContainAllEntries(entries: [string, string][]): void;
+
+    /**
+     * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
+     *
+     * @param {Array.<Array.<String, String>>} entries
+     */
+    toContainAnyEntries(entries: [string, string][]): void;
+
+    /**
+     * Use `.toBeExtensible` when checking if an object is extensible.
+     */
+    toBeExtensible(): void;
+
+    /**
+     * Use `.toBeFrozen` when checking if an object is frozen.
+     */
+    toBeFrozen(): void;
+
+    /**
+     * Use `.toBeSealed` when checking if an object is sealed.
+     */
+    toBeSealed(): void;
+
+    /**
+     * Use `.toBeString` when checking if a value is a `String`.
+     */
+    toBeString(): void;
+
+    /**
+     * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
+     *
+     * @param {String} string
+     */
+    toEqualCaseInsensitive(string: string): void;
+
+    /**
+     * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
+     *
+     * @param {String} prefix
+     */
+    toStartWith(prefix: string): void;
+
+    /**
+     * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
+     *
+     * @param {String} suffix
+     */
+    toEndWith(suffix: string): void;
+
+    /**
+     * Use `.toInclude` when checking if a `String` includes the given `String` substring.
+     *
+     * @param {String} substring
+     */
+    toInclude(substring: string): void;
+
+    /**
+     * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
+     *
+     * @param {String} substring
+     * @param {Number} times
+     */
+    toIncludeRepeated(substring: string, times: number): void;
+
+    /**
+     * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
+     *
+     * @param {Array.<String>} substring
+     */
+    toIncludeMultiple(substring: string[]): void;
 };
 
 type JestExpectType = {
-  not: JestExpectType & EnzymeMatchersType,
+  not: JestExpectType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType,
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -250,7 +594,7 @@ type JestExpectType = {
   /**
    *
    */
-  toHaveProperty(propPath: string, value?: any): void,
+  toHaveProperty(propPath: string | Array<string>, value?: any): void,
   /**
    * Use .toMatch to check that a string matches a regular expression or string.
    */
@@ -258,7 +602,7 @@ type JestExpectType = {
   /**
    * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
    */
-  toMatchObject(object: Object): void,
+  toMatchObject(object: Object | Array<Object>): void,
   /**
    * This ensures that a React component matches the most recent snapshot.
    */
@@ -271,8 +615,8 @@ type JestExpectType = {
    *
    * Alias: .toThrowError
    */
-  toThrow(message?: string | Error | RegExp): void,
-  toThrowError(message?: string | Error | RegExp): void,
+  toThrow(message?: string | Error | Class<Error> | RegExp): void,
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void,
   /**
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.
@@ -311,6 +655,10 @@ type JestObjectType = {
    */
   resetAllMocks(): JestObjectType,
   /**
+   * Restores all mocks back to their original value.
+   */
+  restoreAllMocks(): JestObjectType,
+  /**
    * Removes any pending timers from the timer system.
    */
   clearAllTimers(): void,
@@ -329,7 +677,7 @@ type JestObjectType = {
    * implementation.
    */
   fn<TArguments: $ReadOnlyArray<*>, TReturn>(
-    implementation?: (...args: TArguments) => TReturn,
+    implementation?: (...args: TArguments) => TReturn
   ): JestMockFn<TArguments, TReturn>,
   /**
    * Determines if the given function is a mocked function.
@@ -355,6 +703,16 @@ type JestObjectType = {
     options?: Object
   ): JestObjectType,
   /**
+   * Returns the actual module instead of a mock, bypassing all checks on
+   * whether the module should receive a mock implementation or not.
+   */
+  requireActual(moduleName: string): any,
+  /**
+   * Returns a mock module instead of the actual module, bypassing all checks
+   * on whether the module should be required normally or not.
+   */
+  requireMock(moduleName: string): any,
+  /**
    * Resets the module registry - the cache of all required modules. This is
    * useful to isolate modules where local state might conflict between tests.
    */
@@ -376,6 +734,13 @@ type JestObjectType = {
   /**
    * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
    * or setInterval() and setImmediate()).
+   */
+  advanceTimersByTime(msToRun: number): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   *
+   * Renamed to `advanceTimersByTime`.
    */
   runTimersToTime(msToRun: number): void,
   /**
@@ -410,7 +775,12 @@ type JestObjectType = {
    * Creates a mock function similar to jest.fn but also tracks calls to
    * object[methodName].
    */
-  spyOn(object: Object, methodName: string): JestMockFn<any, any>
+  spyOn(object: Object, methodName: string, accessType?: "get" | "set"): JestMockFn<any, any>,
+  /**
+   * Set the default timeout interval for tests and before/after hooks in milliseconds.
+   * Note: The default timeout interval is 5 seconds if this method is not called.
+   */
+  setTimeout(timeout: number): JestObjectType
 };
 
 type JestSpyType = {
@@ -418,72 +788,99 @@ type JestSpyType = {
 };
 
 /** Runs this function after every test inside this context */
-declare function afterEach(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+declare function afterEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
 /** Runs this function before every test inside this context */
-declare function beforeEach(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+declare function beforeEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
 /** Runs this function after all tests have finished inside this context */
-declare function afterAll(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+declare function afterAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
 /** Runs this function before any tests have started inside this context */
-declare function beforeAll(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+declare function beforeAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
 
 /** A context for grouping tests together */
 declare var describe: {
   /**
    * Creates a block that groups together several related tests in one "test suite"
    */
-  (name: string, fn: () => void): void,
+  (name: JestTestName, fn: () => void): void,
 
   /**
    * Only run this describe block
    */
-  only(name: string, fn: () => void): void,
+  only(name: JestTestName, fn: () => void): void,
 
   /**
    * Skip running this describe block
    */
-  skip(name: string, fn: () => void): void,
+  skip(name: JestTestName, fn: () => void): void
 };
-
 
 /** An individual test unit */
 declare var it: {
   /**
    * An individual test unit
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  (name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
+  (
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
   /**
    * Only run this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  only(name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
+  only(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
   /**
    * Skip running this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  skip(name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
+  skip(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
   /**
    * Run the test concurrently
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  concurrent(name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
+  concurrent(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void
 };
 declare function fit(
-  name: string,
+  name: JestTestName,
   fn: (done: () => void) => ?Promise<mixed>,
-  timeout?: number,
+  timeout?: number
 ): void;
 /** An individual test unit */
 declare var test: typeof it;
@@ -496,23 +893,69 @@ declare var xit: typeof it;
 /** A disabled individual test */
 declare var xtest: typeof it;
 
+type JestPrettyFormatColors = {
+  comment: { close: string, open: string },
+  content: { close: string, open: string },
+  prop: { close: string, open: string },
+  tag: { close: string, open: string },
+  value: { close: string, open: string },
+};
+
+type JestPrettyFormatIndent = string => string;
+type JestPrettyFormatRefs = Array<any>;
+type JestPrettyFormatPrint = any => string;
+type JestPrettyFormatStringOrNull = string | null;
+
+type JestPrettyFormatOptions = {|
+  callToJSON: boolean,
+  edgeSpacing: string,
+  escapeRegex: boolean,
+  highlight: boolean,
+  indent: number,
+  maxDepth: number,
+  min: boolean,
+  plugins: JestPrettyFormatPlugins,
+  printFunctionName: boolean,
+  spacing: string,
+  theme: {|
+    comment: string,
+    content: string,
+    prop: string,
+    tag: string,
+    value: string,
+  |},
+|};
+
+type JestPrettyFormatPlugin = {
+  print: (
+    val: any,
+    serialize: JestPrettyFormatPrint,
+    indent: JestPrettyFormatIndent,
+    opts: JestPrettyFormatOptions,
+    colors: JestPrettyFormatColors,
+  ) => string,
+  test: any => boolean,
+};
+
+type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
+
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType,
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */
-  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,
   hasAssertions(): void,
   any(value: mixed): JestAsymmetricEqualityType,
-  anything(): void,
-  arrayContaining(value: Array<mixed>): void,
-  objectContaining(value: Object): void,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
+  objectContaining(value: Object): Object,
   /** Matches any received string that contains the exact expected string. */
-  stringContaining(value: string): void,
-  stringMatching(value: string | RegExp): void
+  stringContaining(value: string): string,
+  stringMatching(value: string | RegExp): string
 };
 
 // TODO handle return type
@@ -523,20 +966,20 @@ declare function spyOn(value: mixed, method: string): Object;
 declare var jest: JestObjectType;
 
 /**
- * The global Jamine object, this is generally not exposed as the public API,
+ * The global Jasmine object, this is generally not exposed as the public API,
  * using features inside here could break in later versions of Jest.
  */
 declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number,
   any(value: mixed): JestAsymmetricEqualityType,
-  anything(): void,
-  arrayContaining(value: Array<mixed>): void,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
   createSpyObj(
     baseName: string,
     methodNames: Array<string>
   ): { [methodName: string]: JestSpyType },
-  objectContaining(value: Object): void,
-  stringMatching(value: string): void
+  objectContaining(value: Object): Object,
+  stringMatching(value: string): string
 };

--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
     ]
   },
   "flow-coverage-report": {
-    "includeGlob": [
+    "globIncludePatterns": [
       "src/**/*.js"
     ],
-    "type": [
+    "reportTypes": [
       "text",
       "html"
     ]

--- a/src/__tests__/__snapshots__/parser-test.js.snap
+++ b/src/__tests__/__snapshots__/parser-test.js.snap
@@ -4,11 +4,13 @@ exports[`getParser should print the help message 1`] = `
 "usage: PROG [-h] [-v] [-f FLOW_PATH]
             [-o {text,html-table,csv,junit,summary,json}] [--show-summary]
             [--summary-only]
-            [--list-files {all,flow,flowstrict,noflow,flowweak,none}]
+            [--list-files {all,flow,flowstrict,flowstrictlocal,noflow,flowweak,none}]
             [--html-file HTML_FILE] [--csv-file CSV_FILE]
             [--junit-file JUNIT_FILE] [--json-file JSON_FILE]
-            [--summary-file SUMMARY_FILE] [-a] [--allow-weak] [-i INCLUDE]
-            [-x EXCLUDE] [--validate]
+            [--summary-file SUMMARY_FILE] [-a]
+            [--level {any,flowweak,flow,flowstrictlocal,flowstrict}]
+            [--allow-weak] [--require-strict-local] [--require-strict]
+            [-i INCLUDE] [-x EXCLUDE] [--validate]
             [root]
 
 Positional arguments:
@@ -26,11 +28,11 @@ Optional arguments:
   --show-summary        Include summary data. Does not apply to saved file 
                         output or jUnit output. (default: 'false')
   --summary-only        Unused. Switch to --show-summary instead.
-  --list-files {all,flow,flowstrict,noflow,flowweak,none}
+  --list-files {all,flow,flowstrict,flowstrictlocal,noflow,flowweak,none}
                         Filter the list of files based on the reported status.
-                         Use '--allow-weak' to control when flow-weak files 
-                        are included or excluded from the 'flow' or 'noflow' 
-                        checks. (default: '\\"all\\"')
+                         See '--level=flowweak' or '--allow-weak' to control 
+                        when flow-weak files are included or excluded from 
+                        the 'flow' or 'noflow' checks. (default: '\\"all\\"')
   --html-file HTML_FILE
                         Save the html table output directly into HTML_FILE. 
                         (default: 'null')
@@ -46,10 +48,23 @@ Optional arguments:
                         Save a text-format summary of the report into 
                         SUMMARY_FILE. (default: 'null')
   -a, --absolute        Report absolute path names. (default: 'false')
-  --allow-weak          Consider '@flow weak' as a accepable annotation. See 
-                        https://flowtype.org/docs/existing.html#weak-mode for 
-                        reasons why this should only be used temporarily. 
+  --level {any,flowweak,flow,flowstrictlocal,flowstrict}
+                        The minimum strictness required in each file. Levels 
+                        progress in ascending order through: 'any > weak > 
+                        flow > strict-local > strict'. The program will exit 
+                        1 if any file has a level lower than this setting. 
+                        (default: '\\"flow\\"')
+  --allow-weak          Alias for '--level=flowweak'. Consider '@flow weak' 
+                        as an accepable annotation. See https://flowtype.
+                        org/docs/existing.html#weak-mode for reasons why this 
+                        should only be used temporarily. (default: 'false')
+  --require-strict-local
+                        Alias for '--level=flowstrictlocal'. Consider '@flow 
+                        strict-local' as the minimum allowable level. 
                         (default: 'false')
+  --require-strict      Alias for '--level=flowstrict'. Consider '@flow 
+                        strict' as the only accepable annotation. (default: 
+                        'false')
   -i INCLUDE, --include INCLUDE
                         Glob for files to include. Can be set multiple times. 
                         (default: '[\\"**/*.js\\"]')
@@ -58,6 +73,6 @@ Optional arguments:
                         (default: '[\\"+(node_modules build flow-typed)/**/*.
                         js\\"]')
   --validate            Run in validation mode. This injects errors into 
-                        globbed files and checks the flow-annotation status
+                        globbed files and checks the flow-annotation status.
 "
 `;

--- a/src/__tests__/cli-test.js
+++ b/src/__tests__/cli-test.js
@@ -19,7 +19,7 @@ describe('cli', () => {
       expect(result).toEqual({
         validate: false,
         absolute: false,
-        allow_weak: false,
+        level: 'flow',
         exclude: ['+(node_modules|build|flow-typed)/**/*.js'],
         flow_path: 'flow',
         include: ['**/*.js'],
@@ -40,6 +40,34 @@ describe('cli', () => {
       expect(result.root).toMatch(/\//);
       expect(result).toMatchObject({
         root: path.resolve(path.join(__dirname, '../..')),
+      });
+    });
+
+    it('should override defaults when allow_weak is enabled', () => {
+      const result = resolveArgs({allow_weak: true}, DEFAULT_FLAGS);
+      expect(result).toMatchObject({
+        level: 'flowweak',
+      });
+    });
+
+    it('should override defaults when require-strict-local is enabled', () => {
+      const result = resolveArgs({require_strict_local: true}, DEFAULT_FLAGS);
+      expect(result).toMatchObject({
+        level: 'flowstrictlocal',
+      });
+    });
+
+    it('should override defaults when require-strict is enabled', () => {
+      const result = resolveArgs({require_strict: true}, DEFAULT_FLAGS);
+      expect(result).toMatchObject({
+        level: 'flowstrict',
+      });
+    });
+
+    it('should override defaults when level is set', () => {
+      const result = resolveArgs({level: 'any'}, DEFAULT_FLAGS);
+      expect(result).toMatchObject({
+        level: 'any',
       });
     });
 

--- a/src/__tests__/countFailingFiles-test.js
+++ b/src/__tests__/countFailingFiles-test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+import countFailingFiles from '../countFailingFiles';
+import {DEFAULT_FLAGS} from '../types';
+
+describe('countFailingFiles', () => {
+  const report = {
+    files: [],
+    summary: {
+      noflow: 1,
+      flowweak: 2,
+      flow: 4,
+      flowstrictlocal: 8,
+      flowstrict: 16,
+      total: 31,
+    },
+  };
+
+  [
+    ['any', 0],
+    ['flowweak', 1],
+    ['flow', 3],
+    ['flowstrictlocal', 7],
+    ['flowstrict', 15],
+  ].forEach((fixture) => {
+    const [level, expected] = fixture;
+    it(`should return ${expected} for level=${level}`, () => {
+      const flags = {...DEFAULT_FLAGS, level: level};
+      expect(countFailingFiles(report, flags)).toBe(expected);
+    });
+  });
+
+  it('should return 0 for invalid level values', () => {
+    const flags = {...DEFAULT_FLAGS, level: 'unknown'};
+    // $FlowExpectedError: Overriding for test coverage
+    expect(countFailingFiles(report, flags)).toBe(0);
+  });
+});

--- a/src/__tests__/flow-test.js
+++ b/src/__tests__/flow-test.js
@@ -58,7 +58,7 @@ describe('genForceErrors', () => {
   const flags = {
     validate: false,
     absolute: true,
-    allow_weak: false,
+    level: 'flow',
     exclude: [],
     flow_path: 'flow',
     include: [],

--- a/src/__tests__/flowStatusFilter-test.js
+++ b/src/__tests__/flowStatusFilter-test.js
@@ -17,41 +17,41 @@ const BASIC_REPORT = [
 describe('flowStatusFilter', () => {
   it('should return all things when there is a weird status name', () => {
     // $FlowFixMe: Expected error with foobar input
-    expect(BASIC_REPORT.filter(flowStatusFilter('foobar', false))).toHaveLength(5);
+    expect(BASIC_REPORT.filter(flowStatusFilter('foobar', 'flow'))).toHaveLength(5);
     // $FlowFixMe: Expected error with foobar input
-    expect(BASIC_REPORT.filter(flowStatusFilter('foobar', true))).toHaveLength(5);
+    expect(BASIC_REPORT.filter(flowStatusFilter('foobar', 'flowweak'))).toHaveLength(5);
   });
   it('should keep all entries with the `all` filter', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('all', false))).toHaveLength(5);
+    expect(BASIC_REPORT.filter(flowStatusFilter('all', 'flow'))).toHaveLength(5);
   });
 
   it('should remove all entries with the `none` filter', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('none', false))).toHaveLength(0);
+    expect(BASIC_REPORT.filter(flowStatusFilter('none', 'flow'))).toHaveLength(0);
   });
 
   it('should keep only the flow-strict & flow-strict-local files when flowstrict is used', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', false))).toHaveLength(2);
-    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', true))).toHaveLength(2);
+    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', 'flow'))).toHaveLength(2);
+    expect(BASIC_REPORT.filter(flowStatusFilter('flowstrict', 'flowweak'))).toHaveLength(2);
   });
 
   it('should keep only the flow, flow-strict & flow-strict-local files when allowWeak is false', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('flow', false))).toHaveLength(3);
+    expect(BASIC_REPORT.filter(flowStatusFilter('flow', 'flow'))).toHaveLength(3);
   });
 
   it('should keep the flow, flow-strict, flow-strict-local and flow-weak files when allowWeak is true', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('flow', true))).toHaveLength(4);
+    expect(BASIC_REPORT.filter(flowStatusFilter('flow', 'flowweak'))).toHaveLength(4);
   });
 
   it('should always only keep flow-weak files', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('flowweak', false))).toHaveLength(1);
-    expect(BASIC_REPORT.filter(flowStatusFilter('flowweak', true))).toHaveLength(1);
+    expect(BASIC_REPORT.filter(flowStatusFilter('flowweak', 'flow'))).toHaveLength(1);
+    expect(BASIC_REPORT.filter(flowStatusFilter('flowweak', 'flowweak'))).toHaveLength(1);
   });
 
   it('should keep both the no-flow and flow-weak files when allowWeak is false', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('noflow', false))).toHaveLength(2);
+    expect(BASIC_REPORT.filter(flowStatusFilter('noflow', 'flow'))).toHaveLength(2);
   });
 
   it('should keep only the no-flow file when allowWeak is true', () => {
-    expect(BASIC_REPORT.filter(flowStatusFilter('noflow', true))).toHaveLength(1);
+    expect(BASIC_REPORT.filter(flowStatusFilter('noflow', 'flowweak'))).toHaveLength(1);
   });
 });

--- a/src/__tests__/summarizeReport-test.js
+++ b/src/__tests__/summarizeReport-test.js
@@ -4,8 +4,6 @@
  * @flow
  */
 
-jest.mock('glob');
-
 import summarizeReport from '../summarizeReport';
 
 describe('summarizeReport', () => {

--- a/src/countFailingFiles.js
+++ b/src/countFailingFiles.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * @flow
+ */
+
+import type {
+  Flags,
+  StatusReport,
+} from './types';
+
+export default function countFailingFiles(
+  report: StatusReport,
+  flags: Flags,
+): number {
+  const {
+    noflow,
+    flowweak,
+    flow,
+    flowstrictlocal,
+  } = report.summary;
+
+  switch(flags.level) {
+    case 'any':
+      return 0;
+    case 'flowweak':
+      return noflow;
+    case 'flow':
+      return noflow + flowweak;
+    case 'flowstrictlocal':
+      return noflow + flowweak + flow;
+    case 'flowstrict':
+      return noflow + flowweak + flow + flowstrictlocal;
+    default:
+      return 0;
+  }
+}

--- a/src/flowStatusFilter.js
+++ b/src/flowStatusFilter.js
@@ -4,13 +4,19 @@
  * @flow
  */
 
-import type {FlowStatus, StatusEntry, StatusReport, VisibileStatusType} from './types';
+import type {
+  FlowStatus,
+  Level,
+  StatusEntry,
+  StatusReport,
+  VisibileStatusType
+} from './types';
 
 export type EntryFilter = (entry: StatusEntry) => boolean;
 
 export default function makeStatusFilter(
   visibleStatus: VisibileStatusType,
-  allowWeak: boolean,
+  level: Level,
 ): EntryFilter {
   return (entry) => {
     switch (visibleStatus) {
@@ -20,11 +26,11 @@ export default function makeStatusFilter(
         const isFlowOrBetter = entry.status === 'flow strict'
           || entry.status === 'flow strict-local'
           || entry.status === 'flow';
-        return allowWeak
+        return level === 'flowweak'
           ? isFlowOrBetter || entry.status === 'flow weak'
           : isFlowOrBetter;
       case 'noflow':
-        return allowWeak
+        return level === 'flowweak'
           ? entry.status === 'no flow'
           : entry.status === 'no flow' || entry.status === 'flow weak';
       case 'flowweak':

--- a/src/parser.js
+++ b/src/parser.js
@@ -7,7 +7,7 @@
 // $FlowFixMe: package.json is untyped
 import packageJSON from '../package.json';
 import {ArgumentParser} from 'argparse';
-import {DEFAULT_FLAGS, OutputFormats, VisibleStatusTypes} from './types';
+import {DEFAULT_FLAGS, OutputFormats, VisibleLevelTypes, VisibleStatusTypes} from './types';
 
 function printDefault(value) {
   return `(default: '${JSON.stringify(value)}')`;
@@ -54,7 +54,7 @@ export default function getParser(options?: Object = {}): ArgumentParser {
     ['--list-files'],
     {
       action: 'store',
-      help: `Filter the list of files based on the reported status. Use '--allow-weak' to control when flow-weak files are included or excluded from the 'flow' or 'noflow' checks. ${printDefault(DEFAULT_FLAGS.list_files)} `,
+      help: `Filter the list of files based on the reported status. See '--level=flowweak' or '--allow-weak' to control when flow-weak files are included or excluded from the 'flow' or 'noflow' checks. ${printDefault(DEFAULT_FLAGS.list_files)}`,
       choices: VisibleStatusTypes,
     },
   );
@@ -101,10 +101,32 @@ export default function getParser(options?: Object = {}): ArgumentParser {
     },
   );
   parser.addArgument(
+    ['--level'],
+    {
+      action: 'store',
+      help: `The minimum strictness required in each file. Levels progress in ascending order through: 'any > weak > flow > strict-local > strict'. The program will exit 1 if any file has a level lower than this setting. ${printDefault(DEFAULT_FLAGS.level)}`,
+      choices: VisibleLevelTypes,
+    },
+  );
+  parser.addArgument(
     ['--allow-weak'],
     {
       action: 'storeTrue',
-      help: `Consider '@flow weak' as a accepable annotation. See https://flowtype.org/docs/existing.html#weak-mode for reasons why this should only be used temporarily. ${printDefault(DEFAULT_FLAGS.allow_weak)}`,
+      help: `Alias for '--level=flowweak'. Consider '@flow weak' as an accepable annotation. See https://flowtype.org/docs/existing.html#weak-mode for reasons why this should only be used temporarily. ${printDefault(false)}`,
+    },
+  );
+  parser.addArgument(
+    ['--require-strict-local'],
+    {
+      action: 'storeTrue',
+      help: `Alias for '--level=flowstrictlocal'. Consider '@flow strict-local' as the minimum allowable level. ${printDefault(false)}`,
+    },
+  );
+  parser.addArgument(
+    ['--require-strict'],
+    {
+      action: 'storeTrue',
+      help: `Alias for '--level=flowstrict'. Consider '@flow strict' as the only accepable annotation. ${printDefault(false)}`,
     },
   );
   parser.addArgument(
@@ -125,7 +147,7 @@ export default function getParser(options?: Object = {}): ArgumentParser {
     ['--validate'],
     {
       action: 'storeTrue',
-      help: 'Run in validation mode. This injects errors into globbed files and checks the flow-annotation status',
+      help: `Run in validation mode. This injects errors into globbed files and checks the flow-annotation status.`,
     },
   );
   parser.addArgument(

--- a/src/types.js
+++ b/src/types.js
@@ -3,7 +3,9 @@
  */
 
 export type OutputFormat = 'text' | 'html-table' | 'csv' | 'junit' | 'summary' | 'json';
-export type VisibileStatusType = 'all' | 'flow' | 'noflow' | 'flowweak' | 'flowstrict' | 'none';
+export type VisibileStatusType = 'all' | 'noflow' | 'flowweak' | 'flow' | 'flowstrict' | 'flowstrictlocal' | 'none';
+
+export type Level = 'any' | 'flowweak' | 'flow' | 'flowstrictlocal' | 'flowstrict';
 
 export const OutputFormats = {
   text: 'text',
@@ -14,10 +16,19 @@ export const OutputFormats = {
   json: 'json',
 };
 
-export const VisibleStatusTypes = {
+export const VisibleLevelTypes: {[Level]: Level} = {
+  any: 'any',
+  flowweak: 'flowweak',
+  flow: 'flow',
+  flowstrictlocal: 'flowstrictlocal',
+  flowstrict: 'flowstrict',
+};
+
+export const VisibleStatusTypes: {[VisibileStatusType]: VisibileStatusType} = {
   all: 'all',
   flow: 'flow',
   flowstrict: 'flowstrict',
+  flowstrictlocal: 'flowstrictlocal',
   noflow: 'noflow',
   flowweak: 'flowweak',
   none: 'none',
@@ -26,7 +37,10 @@ export const VisibleStatusTypes = {
 export type Args = {
   validate?: boolean,
   absolute?: boolean,
+  level?: Level,
   allow_weak?: boolean,
+  require_strict_local?: boolean,
+  require_strict?: boolean,
   exclude?: Array<string>,
   flow_path?: string,
   include?: Array<string>,
@@ -44,7 +58,7 @@ export type Args = {
 export type Flags = {
   validate: boolean,
   absolute: boolean,
-  allow_weak: boolean,
+  level: Level,
   exclude: Array<string>,
   flow_path: string,
   include: Array<string>,
@@ -62,7 +76,7 @@ export type Flags = {
 export const DEFAULT_FLAGS: Flags = {
   validate: false,
   absolute: false,
-  allow_weak: false,
+  level: 'flow',
   exclude: ['+(node_modules|build|flow-typed)/**/*.js'],
   flow_path: 'flow',
   include: ['**/*.js'],


### PR DESCRIPTION
Transform the previous `--allow-weak` flag into `--level`, so we can set minimum level of strictness for files, and fail if it's not met. Also, tie it into --list-files.

I've split `printStatusReport` so we can decide the exit code separately from the actual printing/saving of the report. 
Finally, `flowstrictlocal` is now a visible status type, so you can see that in the output.

See #78 
