### PR TITLE
Guard against @flow annotations that are after a code statement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,10 +75,7 @@
       "src/**/*.js"
     ],
     "exclude": [
-      "src/__tests__/fixtures/comment-blocks-10.js",
-      "src/__tests__/fixtures/comment-statement-10.js",
-      "src/__tests__/fixtures/flow-weak.js",
-      "src/__tests__/fixtures/no-comments.js"
+      "src/__tests__/fixtures/!(*.flow.js)"
     ]
   },
   "flow-coverage-report": {

--- a/src/__tests__/fixtures/comment-block-after-code.js
+++ b/src/__tests__/fixtures/comment-block-after-code.js
@@ -1,0 +1,3 @@
+// flow is disabled in this file
+const name: string = null;
+/* @flow */

--- a/src/__tests__/fixtures/comment-statement-after-code.js
+++ b/src/__tests__/fixtures/comment-statement-after-code.js
@@ -1,0 +1,3 @@
+// flow is disabled in this file
+const name: string = null;
+// @flow

--- a/src/__tests__/fixtures/use-strict-block-after-code.js
+++ b/src/__tests__/fixtures/use-strict-block-after-code.js
@@ -1,0 +1,4 @@
+'use strict';
+// flow is disabled in this file
+const name: string = null;
+/* @flow */

--- a/src/__tests__/fixtures/use-strict-statement-after-code.js
+++ b/src/__tests__/fixtures/use-strict-statement-after-code.js
@@ -1,0 +1,4 @@
+'use strict';
+// flow is disabled in this file
+const name: string = null;
+// @flow

--- a/src/__tests__/flow-test.js
+++ b/src/__tests__/flow-test.js
@@ -26,6 +26,10 @@ const flowDetectedFixtures = [
 const flowFailedFixtures = [
   {status: 'no flow', file: './fixtures/comment-blocks-10.js'},
   {status: 'no flow', file: './fixtures/comment-statement-10.js'},
+  {status: 'no flow', file: './fixtures/comment-block-after-code.js'},
+  {status: 'no flow', file: './fixtures/comment-statement-after-code.js'},
+  {status: 'no flow', file: './fixtures/comment-block-after-code.js'},
+  {status: 'no flow', file: './fixtures/use-strict-block-after-code.js'},
   {status: 'no flow', file: './fixtures/no-comments.js'},
   {status: 'flow weak', file: './fixtures/flow-weak.js'},
 ];


### PR DESCRIPTION
This is to match up with the condition "stop looking for docblocks if we see tokens other than string|semicolon": https://github.com/facebook/flow/blob/d144c67f70b420e0366b442d9782659f3d35900b/src/parsing/parsing_service_js.ml#L324-L327

fixes #97 