### PR TITLE
Let TravisCI only build the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 branches:
   only:
-  - master
+    - master
   
 node_js:
   - node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 
+branches:
+  only:
+  - master
+  
 node_js:
   - node
   - 12

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 branches:
   only:
     - master
-  
+
 node_js:
   - node
   - 12


### PR DESCRIPTION
This will tell TravisCI to skip feature branches, which should run as pull-request builds only.