### PR TITLE
Really ignore tests when packaging 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/
 npm-debug.log
 flow-coverage/
 coverage/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "flow:check": "flow check && flow check ./src/__tests__/fixtures",
     "flow:annotations": "npm run transpile && bin/flow-annotation-check.js",
     "flow:coverage": "npx flow-coverage-report",
-    "transpile": "rm -Rf lib/* && babel src --out-dir lib --ignore __tests__"
+    "transpile": "rm -Rf lib/* && babel src --out-dir lib --ignore \"**/__tests__\""
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
When updating dependencies I noticed that we couldn't install this module on Windows (see [the output of appveyor](https://ci.appveyor.com/project/julienw/profiler/builds/35566782)) because of test files, which was curious. So I've been curious too :-) and noticed that tests were actually supposed to be excluded... but that didn't work.

So here is a fix for that!

I also added a commit to add package-lock.json to the gitignore file.

Would you be kind enough to do a quick release after that, so that I can move forward with updating our dependencies? Thanks so much!